### PR TITLE
Fix for IE 9+

### DIFF
--- a/coffee/shepherd.coffee
+++ b/coffee/shepherd.coffee
@@ -14,7 +14,7 @@ createFromHTML = (html) ->
   el.children[0]
 
 matchesSelector = (el, sel) ->
-  matches = el.matches ? el.msMatchesSelector ? el.webkitMatchesSelector ? el.mozMatchesSelector ? el.oMatchesSelector
+  matches = el.matches ? el.matchesSelector ? el.msMatchesSelector ? el.webkitMatchesSelector ? el.mozMatchesSelector ? el.oMatchesSelector
   return matches.call(el, sel)
 
 parseShorthand = (obj, props) ->

--- a/js/shepherd.js
+++ b/js/shepherd.js
@@ -23,8 +23,8 @@
   };
 
   matchesSelector = function(el, sel) {
-    var matches, _ref1, _ref2, _ref3, _ref4;
-    matches = (_ref1 = (_ref2 = (_ref3 = (_ref4 = el.matches) != null ? _ref4 : el.msMatchesSelector) != null ? _ref3 : el.webkitMatchesSelector) != null ? _ref2 : el.mozMatchesSelector) != null ? _ref1 : el.oMatchesSelector;
+    var matches, _ref1, _ref2, _ref3, _ref4, _ref5;
+    matches = (_ref1 = (_ref2 = (_ref3 = (_ref4 = (_ref5 = el.matches) != null ? _ref5 : el.msMatchesSelector) != null ? _ref4 : el.matchesSelector) != null ? _ref3 : el.webkitMatchesSelector) != null ? _ref2 : el.mozMatchesSelector) != null ? _ref1 : el.oMatchesSelector;
     return matches.call(el, sel);
   };
 


### PR DESCRIPTION
Fixes #23

MatchesSelector is not compatible with IE 9+. This patch fixes it so IE 9+ can understand the matchesSelector.
https://developer.mozilla.org/en-US/docs/Web/API/Element.matches

MatchesSelector compatibility: 
IE 9.0 with the non-standard name msMatchesSelector
