### PR TITLE
check for null returned when an element for a step is not found

### DIFF
--- a/src/js/shepherd.js
+++ b/src/js/shepherd.js
@@ -239,7 +239,7 @@ class Step extends Evented {
 
     let opts = this.getAttachTo();
     let attachment = ATTACHMENT[opts.on || 'right'] || opts.on;
-    if (isUndefined(opts.element)) {
+    if (opts.element === null || isUndefined(opts.element)) {
       opts.element = 'viewport';
       attachment = 'middle center';
     }


### PR DESCRIPTION
If getAttachTo() fails to find an element passed over as a string, it sets that element to null.  This bypasses the check in setupTether which only checks if opts.element is undefined and the step does not get shown leaving the tour in an undetermined state.

This fix checks for null and presents the step in the middle of the viewport as expected.
