### PR TITLE
Update documentation link in demo tour

### DIFF
--- a/docs/welcome/js/welcome.js
+++ b/docs/welcome/js/welcome.js
@@ -46,7 +46,7 @@
     });
     shepherd.addStep('example', {
       title: 'Example Shepherd',
-      text: 'Creating a Shepherd is easy too! Just create Shepherd and add as many steps as you want. Check out the <a href="http://github.hubspot.com/shepherd">documentation</a> to learn more.',
+      text: 'Creating a Shepherd is easy too! Just create Shepherd and add as many steps as you want. Check out the <a href="https://shipshapecode.github.io/shepherd/">documentation</a> to learn more.',
       attachTo: '.hero-example bottom',
       buttons: [
         {


### PR DESCRIPTION
Looks like the link to the docs in the demo tour was using an old URL.