### PR TITLE
Syntax errors and ParentNode.prepend not supported in IE

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -219,7 +219,7 @@ export class Step extends Evented {
       const title = document.createElement('h3');
       title.classList.add('shepherd-title');
       title.innerHTML = `${this.options.title}`;
-      header.prepend(title);
+      header.appendChild(title);
       element.classList.add('shepherd-has-title');
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -175,12 +175,7 @@ module.exports.push({
         include: [
           path.resolve(__dirname, 'src/js')
         ],
-        use: [{
-          loader: 'babel-loader',
-          options: {
-            'presets': ['@babel/env']
-          }
-        }]
+        loader: 'babel-loader'
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -175,7 +175,12 @@ module.exports.push({
         include: [
           path.resolve(__dirname, 'src/js')
         ],
-        loader: 'babel-loader'
+        use: [{
+          loader: 'babel-loader',
+          options: {
+            'presets': ['@babel/env']
+          }
+        }]
       }
     ]
   },


### PR DESCRIPTION
I was testing with release **2.0.0-beta-24 in IE** and some errors occurred. [Issue 238](https://github.com/shipshapecode/shepherd/issues/238)

Basically putting the `babel/env` back in the webpack config seem make IE load the lib instead of giving us the awful `Syntax Errors` message.

Also, [ParentNode.prepend](https://developer.mozilla.org/fr/docs/Web/API/ParentNode/append) is not fully supported by all the browsers, so it's probably better not to use it since it doesn't seem to be needed in this case.

Cheers!

Resolves #238 