### PR TITLE
use uniqueId for step ID prop over idAttribute

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -212,7 +212,7 @@ export class Step extends Evented {
   _createElement() {
     const content = document.createElement('div');
     const classes = this.options.classes || '';
-    const element = createFromHTML(`<div class='${classes}' data-id='${this.id}' id="${this.options.idAttribute}"}>`);
+    const element = createFromHTML(`<div class='${classes}' data-id='${this.id}' id="step-${this.options.id}-${uniqueId()}"}>`);
     const header = document.createElement('header');
 
     if (this.options.title) {


### PR DESCRIPTION
the ID for the main step DIV is always `undefined` currently, this sets it more explicitly as the options hash did not include `idAttribute`.