### PR TITLE
Remove default arrow setting on centered tippy

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -171,6 +171,7 @@ function _makeCenteredTippy() {
     positionFixed: true
   };
 
+  tippyOptions.arrow = false;
   tippyOptions.popperOptions = tippyOptions.popperOptions || {};
 
   const finalPopperOptions = Object.assign(


### PR DESCRIPTION
This removes the arrow: true setting if we `_makeCenteredTippy()` since it's not attached to an element that an arrow could point to. 