### PR TITLE
Allow exit animations to play before step tooltip disappears.

### DIFF
--- a/src/js/bind.js
+++ b/src/js/bind.js
@@ -6,10 +6,11 @@ import { forOwn, isString, isUndefined } from 'lodash';
  * @private
  */
 function _setupAdvanceOnHandler(selector) {
-  return (e) => {
+  return (event) => {
     if (this.isOpen()) {
-      const targetIsEl = this.el && e.target === this.el;
-      const targetIsSelector = !isUndefined(selector) && e.target.matches(selector);
+      const targetIsEl = this.el && event.target === this.el;
+      const targetIsSelector = !isUndefined(selector) && event.target.matches(selector);
+
       if (targetIsSelector || targetIsEl) {
         this.tour.next();
       }

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -247,14 +247,10 @@ export class Step extends Evented {
    * Triggers `destroy` event
    */
   destroy() {
-    if (isElement(this.el) && this.el.parentNode) {
-      this.el.parentNode.removeChild(this.el);
-      delete this.el;
-    }
-
     if (this.tooltip) {
       this.tooltip.destroy();
       this.tooltip = null;
+      this.el = null;
     }
 
     this.trigger('destroy');
@@ -265,12 +261,6 @@ export class Step extends Evented {
    */
   hide() {
     this.trigger('before-hide');
-
-    if (this.el) {
-      this.el.hidden = true;
-      // We need to manually set styles for < IE11 support
-      this.el.style.display = 'none';
-    }
 
     document.body.removeAttribute('data-shepherd-step');
 
@@ -290,7 +280,11 @@ export class Step extends Evented {
    * @return {boolean} True if the step is open and visible
    */
   isOpen() {
-    return Boolean(this.el && !this.el.hidden);
+    return Boolean(
+      this.tooltip &&
+      this.tooltip.state &&
+      this.tooltip.state.isVisible
+    );
   }
 
   /**

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -250,7 +250,15 @@ export class Step extends Evented {
     if (this.tooltip) {
       this.tooltip.destroy();
       this.tooltip = null;
+    }
+
+    if (this.el && this.el instanceof HTMLElement) {
+      this.el.parentNode.removeChild(this.el);
       this.el = null;
+    }
+
+    if (this.target) {
+      this.target.classList.remove('shepherd-enabled', 'shepherd-target');
     }
 
     this.trigger('destroy');

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -252,7 +252,7 @@ export class Step extends Evented {
       this.tooltip = null;
     }
 
-    if (this.el && this.el instanceof HTMLElement) {
+    if (isElement(this.el) && this.el.parentNode) {
       this.el.parentNode.removeChild(this.el);
       this.el = null;
     }

--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -1,4 +1,4 @@
-import { isFunction, isNumber, isString, isUndefined } from 'lodash';
+import { isFunction, isNumber, isString, isUndefined, isEmpty } from 'lodash';
 import { Evented } from './evented.js';
 import { Step } from './step.js';
 import { bindMethods } from './bind.js';
@@ -112,17 +112,11 @@ export class Tour extends Evented {
    * @param {String} event The event name to trigger
    */
   done(event) {
-    if (this.currentStep) {
-      this.currentStep.hide();
+    if (!isEmpty(this.steps)) {
+      this.steps.forEach((step) => step.destroy());
     }
 
     this.trigger(event);
-
-    if (Shepherd.activeTour) {
-      Shepherd.activeTour.steps.forEach((step) => {
-        step.destroy();
-      });
-    }
 
     Shepherd.activeTour = null;
     document.body.classList.remove('shepherd-active');
@@ -224,6 +218,10 @@ export class Tour extends Evented {
    * @param {Boolean} forward True if we are going forward, false if backward
    */
   show(key = 0, forward = true) {
+    if (this.currentStep) {
+      this.currentStep.hide();
+    }
+
     this._setupActiveTour();
 
     const step = isString(key) ? this.getById(key) : this.steps[key];
@@ -258,17 +256,12 @@ export class Tour extends Evented {
   }
 
   /**
-   * If we have a currentStep, the tour is active, so just hide the step and remain active.
-   * Otherwise, make the tour active.
+   * Make this tour "active"
    * @private
    */
   _setupActiveTour() {
-    if (this.currentStep) {
-      this.currentStep.hide();
-    } else {
-      document.body.classList.add('shepherd-active');
-      this.trigger('active', { tour: this });
-    }
+    document.body.classList.add('shepherd-active');
+    this.trigger('active', { tour: this });
 
     Shepherd.activeTour = this;
   }

--- a/src/js/utils/tooltip-defaults.js
+++ b/src/js/utils/tooltip-defaults.js
@@ -3,7 +3,6 @@ export const defaults = {
   arrow: true,
   arrowTransform: 'scale(2)',
   animation: 'fade',
-  delay: 200,
   duration: 420,
   flip: true,
   animateFill: false, // https://atomiks.github.io/tippyjs/#animate-fill-option

--- a/test/cypress/integration/element-targeting.spec.js
+++ b/test/cypress/integration/element-targeting.spec.js
@@ -18,8 +18,17 @@ describe('Attaching tooltips to target elements in the DOM on each step', () => 
   });
 
   describe('Adding/Removing class names to the target of the current step', () => {
+    let tour;
+
+    beforeEach(() => {
+      tour = setupTour(Shepherd);
+    });
+
+    afterEach(() => {
+      tour.complete();
+    });
+
     it('Adds the "shepherd-target" and "shepherd-enabled" classes upon showing a step', () => {
-      const tour = setupTour(Shepherd);
       tour.start();
 
       cy.get('.hero-welcome')
@@ -28,7 +37,6 @@ describe('Attaching tooltips to target elements in the DOM on each step', () => 
     });
 
     it('Removes the "shepherd-target" and "shepherd-enabled" upon hiding a step', () => {
-      const tour = setupTour(Shepherd);
       tour.start();
       tour.next();
 

--- a/test/cypress/integration/test.acceptance.js
+++ b/test/cypress/integration/test.acceptance.js
@@ -224,20 +224,5 @@ describe('Shepherd Acceptance Tests', () => {
         cy.get('.shepherd-step-element').should('have.length', 1);
       });
     });
-
-    describe('Cleaning up', () => {
-      let tour;
-
-      beforeEach(() => {
-        tour = setupTour(Shepherd);
-        tour.start();
-      });
-
-      it('renders no steps after the tour completes', () => {
-        tour.complete();
-
-        cy.get('.shepherd-step-element').should('not.exist');
-      });
-    });
   });
 });

--- a/test/cypress/integration/test.acceptance.js
+++ b/test/cypress/integration/test.acceptance.js
@@ -226,10 +226,14 @@ describe('Shepherd Acceptance Tests', () => {
     });
 
     describe('Cleaning up', () => {
-      it('renders no steps when the tour completes', () => {
-        const tour = setupTour(Shepherd);
+      let tour;
 
+      beforeEach(() => {
+        tour = setupTour(Shepherd);
         tour.start();
+      });
+
+      it('renders no steps after the tour completes', () => {
         tour.complete();
 
         cy.get('.shepherd-step-element').should('not.exist');

--- a/test/unit/test.step.js
+++ b/test/unit/test.step.js
@@ -12,19 +12,21 @@ import defaultButtons from '../cypress/utils/default-buttons';
 // since importing non UMD, needs assignment
 window.Shepherd = Shepherd;
 
+const DEFAULT_STEP_CLASS = 'shepherd-step-tooltip';
+
 describe('Step', () => {
   describe('Shepherd.Step()', () => {
     const instance = new Shepherd.Tour({
       defaultStepOptions: {
-        classes: 'shepherd-theme-arrows',
+        classes: DEFAULT_STEP_CLASS,
         scrollTo: true
       }
     });
 
     const testStep = instance.addStep('test', {
+      attachTo: 'body',
       id: 'test',
       text: 'This is a step for testing',
-      classes: 'example-step-extra-class',
       buttons: [
         {
           text: 'Next',
@@ -67,16 +69,21 @@ describe('Step', () => {
 
 
     it('has all the correct properties', () => {
-      const values = ['classes', 'scrollTo', 'id', 'text', 'buttons'];
+      const values = ['classes', 'scrollTo', 'attachTo', 'id', 'text', 'buttons'];
       assert.deepEqual(values, Object.keys(testStep.options));
     });
 
     describe('.hide()', () => {
-      it('shows step evoking method, regardless of order', () => {
+      it('detaches from the step target', () => {
         instance.start();
+
+        const targetElem = document.body;
+
+        assert.equal(targetElem.classList.contains('shepherd-enabled'), true);
+
         testStep.hide();
 
-        assert.notEqual(document.querySelector('[data-id=test]').getAttribute('hidden'), null);
+        assert.equal(targetElem.classList.contains('shepherd-enabled'), false);
       });
     });
 
@@ -95,111 +102,108 @@ describe('Step', () => {
   });
 
   describe('bindAdvance()', () => {
-    it('should trigger the advanceOn option via string', () => {
-      const el = document.createElement('div');
-      const event = new Event('test');
-      const link = document.createElement('a');
-      let advanced = false;
-      link.classList.add('click-test');
-      document.body.appendChild(link);
+    let tooltipElem;
+    let event;
+    let link;
+    let hasAdvanced = false;
 
-      const step = new Step({
-        next: () => advanced = true
-      }, {
-        advanceOn: '.click-test test'
+    const advanceOnSelector = 'test-selector';
+    const advanceOnEventName = 'test-event';
+    const tourProto = {
+      next() { hasAdvanced = true; }
+    };
+
+    before(() => {
+      tooltipElem = document.createElement('div');
+      event = new Event(advanceOnEventName);
+
+      link = document.createElement('a');
+      link.classList.add(advanceOnSelector);
+      link.textContent = 'Click Me 👋';
+
+      document.body.appendChild(link);
+    });
+
+    after(() => {
+      link.remove();
+    });
+
+    it('triggers the `advanceOn` option via string', () => {
+      const step = new Step(tourProto, {
+        advanceOn: `.${advanceOnSelector} ${advanceOnEventName}`
       });
-      step.el = el;
-      step.el.hidden = false;
+
+      step.isOpen = () => true;
 
       step.bindAdvance();
       link.dispatchEvent(event);
 
-      assert.isOk(link.classList.contains('click-test'));
-      assert.isOk(advanced);
+      assert.equal(link.classList.contains(advanceOnSelector), true);
+      assert.equal(hasAdvanced, true);
     });
 
-    it('should trigger the advanceOn option via object', () => {
-      const el = document.createElement('div');
-      const event = new Event('test');
-      const link = document.createElement('a');
-      let advanced = false;
-      link.classList.add('object-test');
-      document.body.appendChild(link);
-
-      const step = new Step({
-        next: () => advanced = true
-      }, {
-        advanceOn: { selector: '.object-test', event: 'test' }
+    it('triggers the `advanceOn` option via object', () => {
+      const step = new Step(tourProto, {
+        advanceOn: { selector: `.${advanceOnSelector}`, event: advanceOnEventName }
       });
-      step.el = el;
-      step.el.hidden = false;
+
+      step.isOpen = () => true;
 
       step.bindAdvance();
       link.dispatchEvent(event);
 
-      assert.isOk(link.classList.contains('object-test'));
-      assert.isOk(advanced, 'next triggered for advanceOn');
+      assert.equal(link.classList.contains(advanceOnSelector), true);
+      assert.equal(hasAdvanced, true, '`next()` triggered for advanceOn');
     });
 
-    it('should capture events attached to no selector', () => {
-      const event = new Event('test');
-      let advanced = false;
-
-      const step = new Step({
-        next: () => advanced = true
-      }, {
-        advanceOn: { event: 'test' }
+    it('captures events attached to no element', () => {
+      const step = new Step(tourProto, {
+        advanceOn: { event: advanceOnEventName }
       });
 
-      step.el = document.body;
-      step.el.hidden = false;
+      step.isOpen = () => true;
 
       step.bindAdvance();
       document.body.dispatchEvent(event);
 
-      assert.isOk(advanced, 'next triggered for advanceOn');
+      assert.isOk(hasAdvanced, '`next()` triggered for advanceOn');
     });
 
     it('should support bubbling events for nodes that do not exist yet', () => {
       const event = new Event('blur');
-      let advanced = false;
 
-      const step = new Step({
-        next: () => advanced = true
-      }, {
+      const step = new Step(tourProto, {
         text: 'Lorem ipsum dolor: <a href="https://example.com">sit amet</a>',
         advanceOn: {
           selector: 'a[href="https://example.com"]',
           event: 'blur'
         }
       });
-      step.el = document.body;
-      step.el.hidden = false;
+
+      step.isOpen = () => true;
 
       step.bindAdvance();
       document.body.dispatchEvent(event);
 
-      assert.isOk(advanced, 'next triggered for advanceOn');
+      assert.isOk(hasAdvanced, '`next()` triggered for advanceOn');
     });
 
-    it('it should call removeEventListener when destoryed', function(done){
-      const el = document.createElement('div');
-      const body = spy(document.body, 'removeEventListener');
-      const step = new Step({
-        next: () => true
-      }, {
-        advanceOn: { event: 'test' }
+    it('calls `removeEventListener` when destroyed', function(done){
+      const bodySpy = spy(document.body, 'removeEventListener');
+      const step = new Step(tourProto, {
+        advanceOn: { event: advanceOnEventName }
       });
-      step.el = el;
-      step.el.hidden = false;
+
+      step.isOpen = () => true;
 
       step.bindAdvance();
       step.trigger('destroy');
-      assert.ok(body.called);
-      body.restore();
+
+      assert.equal(bodySpy.called, true);
+      bodySpy.restore();
+
       done();
     });
-
   });
 
   describe('bindButtonEvents()', () => {

--- a/test/unit/test.step.js
+++ b/test/unit/test.step.js
@@ -7,6 +7,7 @@ const { assert } = chai;
 import Shepherd from '../../src/js/shepherd.js';
 import { Step } from '../../src/js/step.js';
 import { Tour } from '../../src/js/tour.js';
+import tippy from 'tippy.js';
 import defaultButtons from '../cypress/utils/default-buttons';
 
 // since importing non UMD, needs assignment
@@ -14,7 +15,7 @@ window.Shepherd = Shepherd;
 
 const DEFAULT_STEP_CLASS = 'shepherd-step-tooltip';
 
-describe('Step', () => {
+describe('Tour | Step', () => {
   describe('Shepherd.Step()', () => {
     const instance = new Shepherd.Tour({
       defaultStepOptions: {
@@ -63,10 +64,13 @@ describe('Step', () => {
       }
     });
 
-    after(() => {
-      instance.cancel();
+    beforeEach(() => {
+      tippy.disableAnimations();
     });
 
+    afterEach(() => {
+      instance.complete();
+    });
 
     it('has all the correct properties', () => {
       const values = ['classes', 'scrollTo', 'attachTo', 'id', 'text', 'buttons'];
@@ -102,7 +106,6 @@ describe('Step', () => {
   });
 
   describe('bindAdvance()', () => {
-    let tooltipElem;
     let event;
     let link;
     let hasAdvanced = false;
@@ -114,7 +117,8 @@ describe('Step', () => {
     };
 
     before(() => {
-      tooltipElem = document.createElement('div');
+      const tooltipElem = document.createElement('div');
+
       event = new Event(advanceOnEventName);
 
       link = document.createElement('a');


### PR DESCRIPTION
Closes https://github.com/shipshapecode/shepherd/issues/277

This removes our own manual management of `this.el`'s appearance/presence
in the DOM -- since tippy is handling it already. 

This allows the tooltip's exit animation to play, as opposed to having the element disappear instantly before we even call `tippy.hide`.