### PR TITLE
Remove unnecessary management of `this.el.hidden`

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -368,10 +368,6 @@ export class Step extends Evented {
       this.setupElements();
     }
 
-    this.el.hidden = false;
-    // We need to manually set styles for < IE11 support
-    this.el.style.display = 'block';
-
     this.target.classList.add('shepherd-enabled', 'shepherd-target');
 
     document.body.setAttribute('data-shepherd-step', this.id);


### PR DESCRIPTION
This really just follows up on https://github.com/shipshapecode/shepherd/pull/279/files#diff-354d9d7aea6f76456f934d7424a3eac4L269, since we no longer need to manually manage `this.el.hidden`.