### PR TITLE
fix: turn off passive events for touchmove on Safari > 10

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -84,7 +84,7 @@ function addStepEventListeners() {
 
   const overlay = document.querySelector(`#${elementIds.modalOverlay}`);
   // Prevents window from moving on touch.
-  window.addEventListener('touchmove', preventModalBodyTouch, false);
+  window.addEventListener('touchmove', preventModalBodyTouch, { passive: false }
 
   // Allows content to move on touch.
   if (overlay) {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -84,7 +84,7 @@ function addStepEventListeners() {
 
   const overlay = document.querySelector(`#${elementIds.modalOverlay}`);
   // Prevents window from moving on touch.
-  window.addEventListener('touchmove', preventModalBodyTouch, { passive: false }
+  window.addEventListener('touchmove', preventModalBodyTouch, { passive: false });
 
   // Allows content to move on touch.
   if (overlay) {


### PR DESCRIPTION
This branch adds the false passive option which is now turned on by default, not allow for preventDefault() calls in listener callbacks.

https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html