### PR TITLE
Adds missing 'hide' to binded methods list in Tour

### DIFF
--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -64,6 +64,7 @@ export class Tour extends Evented {
       'back',
       'cancel',
       'complete',
+      'hide',
       'next'
     ]);
     this.options = options;


### PR DESCRIPTION
Unless `hide` is part of the binded methods list the scope later on in Tour#hide (https://github.com/seppsepp/shepherd/blob/master/src/js/tour.js#L197-L203) is wrong and there `this` is for example `<a class="shepherd-button " data-button-event="true">Proceed</a>` so that `this.getCurrentStep()` must fail. If `hide` is in the list then the scope is correct and `this` is of instance `Tour`.

(Without this change adding `action: tour.hide` to a button definition breaks an app.)