### PR TITLE
svg mask for the opening in browsers do not support getBoundingClientRect().x|y

### DIFF
--- a/src/js/utils/modal.js
+++ b/src/js/utils/modal.js
@@ -130,9 +130,9 @@ function createModalOverlay() {
  */
 function positionModalOpening(targetElement, openingElement) {
   if (targetElement.getBoundingClientRect && openingElement instanceof SVGElement) {
-    const { x, y, width, height } = targetElement.getBoundingClientRect();
+    const { x, y, width, height, left, top } = targetElement.getBoundingClientRect();
 
-    _setAttributes(openingElement, { x, y, width, height });
+    _setAttributes(openingElement, { x:  x || left, y: y || top, width, height });
   }
 }
 


### PR DESCRIPTION
[Yandex browser](https://en.wikipedia.org/wiki/Yandex_Browser) not support getBoundingClientRect().x.