### PR TITLE
Add tabindex="0" to shepherd-button

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -126,7 +126,7 @@ export class Step extends Evented {
       footer.classList.add('shepherd-footer');
 
       this.options.buttons.map((cfg) => {
-        const button = createFromHTML(`<li><a class="shepherd-button ${cfg.classes || ''}">${cfg.text}</a>`);
+        const button = createFromHTML(`<li><a class="shepherd-button ${cfg.classes || ''}" tabindex="0">${cfg.text}</a>`);
         buttons.appendChild(button);
         this.bindButtonEvents(cfg, button.querySelector('a'));
       });


### PR DESCRIPTION
Added tabindex="0" to shepherd-button to fix the following:

- bootstrap 4 styling needs a href or tabindex to work properly (otherwise some colors aren't correctly applied) (see: https://github.com/twbs/bootstrap/blob/bc60a22a1843928814099ef5e6e26552f55aebae/dist/css/bootstrap.css#L166) 
- https://stackoverflow.com/a/10510353 (adding the role would be optional and scope of another pr?)