### PR TITLE
Remove addStepEventListeners call

### DIFF
--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -12,7 +12,6 @@ import {
 } from './utils/cleanup';
 
 import {
-  addStepEventListeners,
   getElementForStep
 } from './utils/dom';
 
@@ -302,7 +301,6 @@ export class Tour extends Evented {
 
     this.currentStep = null;
     this._setupActiveTour();
-    addStepEventListeners.call(this);
     this.next();
   }
 


### PR DESCRIPTION
I am not 100% sure if removing this is okay or not. @chuckcarpenter do you know why we had this call here? Is `addStepEventListeners` only necessary when using modal mode?

Fixes #393 