### PR TITLE
Remove ul, li button wrapper

### DIFF
--- a/docs/welcome/css/welcome.css
+++ b/docs/welcome/css/welcome.css
@@ -100,37 +100,21 @@ pre {
   line-height: 1.4em;
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button {
-  display: inline-block;
-  *display: inline;
-  vertical-align: middle;
-  *vertical-align: auto;
-  *zoom: 1;
+.shepherd-element .shepherd-content footer .shepherd-button {
   background: #55a892;
-  border: 0;
-  border-radius: 3px;
   color: rgba(255, 255, 255, 0.75);
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 0.8em;
-  letter-spacing: 0.1em;
-  line-height: 1em;
-  padding: 0.75em 2em;
-  text-transform: uppercase;
-  -webkit-transition: all 0.5s ease;
-  transition: all 0.5s ease;
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button:hover {
+.shepherd-element .shepherd-content footer .shepherd-button:hover {
   background: #448675;
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button.shepherd-button-secondary {
+.shepherd-element .shepherd-content footer .shepherd-button.shepherd-button-secondary {
   background: #e5e5e5;
   color: rgba(0, 0, 0, 0.75);
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button.shepherd-button-secondary:hover {
+.shepherd-element .shepherd-content footer .shepherd-button.shepherd-button-secondary:hover {
   background: #cbcbcb;
   color: rgba(0, 0, 0, 0.75);
 }

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -148,17 +148,17 @@ export class Step extends Evented {
   _addButtons(content) {
     if (Array.isArray(this.options.buttons) && this.options.buttons.length) {
       const footer = document.createElement('footer');
-      const buttons = createFromHTML('<ul class="shepherd-buttons"></ul>');
 
       footer.classList.add('shepherd-footer');
 
       this.options.buttons.map((cfg) => {
-        const button = createFromHTML(`<li><button class="shepherd-button ${cfg.classes || ''}" tabindex="0">${cfg.text}</button>`);
-        buttons.appendChild(button);
-        this.bindButtonEvents(cfg, button.querySelector('button'));
+        const button = createFromHTML(
+          `<button class="shepherd-button ${cfg.classes || ''}" tabindex="0">${cfg.text}</button>`
+        );
+        footer.appendChild(button);
+        this.bindButtonEvents(cfg, button);
       });
 
-      footer.appendChild(buttons);
       content.appendChild(footer);
     }
   }
@@ -217,7 +217,7 @@ export class Step extends Evented {
     const KEY_ESC = 27;
 
     element.addEventListener('keydown', (e) => {
-      switch(e.keyCode) {
+      switch (e.keyCode) {
         case KEY_ESC:
           this.cancel();
           break;

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -98,25 +98,15 @@
     footer {
       border-bottom-left-radius: $shepherd-element-border-radius;
       border-bottom-right-radius: $shepherd-element-border-radius;
+      display: flex;
+      justify-content: flex-end;
       padding: 0 0.75em 0.75em;
 
-      .shepherd-buttons {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        text-align: right;
+      .shepherd-button {
+        @include shepherd-button;
 
-        li {
-          display: inline;
-          margin: 0 0.5em 0 0;
-
-          &:last-child {
-            margin-right: 0;
-          }
-
-          .shepherd-button {
-            @include shepherd-button;
-          }
+        &:last-child {
+          margin-right: 0;
         }
       }
     }

--- a/src/scss/mixins/_shepherd-button.scss
+++ b/src/scss/mixins/_shepherd-button.scss
@@ -6,10 +6,12 @@
   border-radius: $shepherd-button-border-radius;
   color: map_get($shepherd-theme-text-colors, primary);
   cursor: pointer;
+  display: inline;
   font-family: inherit;
   font-size: 0.8em;
   letter-spacing: 0.1em;
   line-height: 1em;
+  margin-right: 0.5em;
   padding: 0.75em 2em;
   text-transform: uppercase;
   transition: all 0.5s ease;

--- a/test/dummy/css/welcome.css
+++ b/test/dummy/css/welcome.css
@@ -333,53 +333,26 @@ pre {
   padding: 0 0.75em 0.75em;
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  text-align: right;
-}
-
-.shepherd-element .shepherd-content footer .shepherd-buttons li {
+.shepherd-element .shepherd-content footer {
   display: inline;
   margin: 0 0.5em 0 0;
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons li:last-child {
-  margin-right: 0;
-}
-
-.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button {
-  display: inline-block;
-  *display: inline;
-  vertical-align: middle;
-  *vertical-align: auto;
-  *zoom: 1;
+.shepherd-element .shepherd-content footer .shepherd-button {
   background: #55a892;
-  border: 0;
-  border-radius: 3px;
   color: rgba(255, 255, 255, 0.75);
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 0.8em;
-  letter-spacing: 0.1em;
-  line-height: 1em;
-  padding: 0.75em 2em;
-  text-transform: uppercase;
-  -webkit-transition: all 0.5s ease;
-  transition: all 0.5s ease;
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button:hover {
+.shepherd-element .shepherd-content footer .shepherd-button:hover {
   background: #448675;
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button.shepherd-button-secondary {
+.shepherd-element .shepherd-content footer .shepherd-button.shepherd-button-secondary {
   background: #e5e5e5;
   color: rgba(0, 0, 0, 0.75);
 }
 
-.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button.shepherd-button-secondary:hover {
+.shepherd-element .shepherd-content footer .shepherd-button.shepherd-button-secondary:hover {
   background: #cbcbcb;
   color: rgba(0, 0, 0, 0.75);
 }

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -555,7 +555,7 @@ describe('Tour | Step', () => {
 
       expect(content.children.length).toBe(1);
 
-      const buttonContainer = content.querySelector('.shepherd-buttons');
+      const buttonContainer = content.querySelector('.shepherd-footer');
 
       expect(buttonContainer instanceof HTMLElement).toBe(true);
 


### PR DESCRIPTION
This removes the `shepherd-buttons` wrapper, which I think is no longer really needed. However, we may need to consider this a breaking change, if people have custom styles that rely on the `ul`, `li` stuff.

This was also requested as better for a11y in #198 