### PR TITLE
Remove string option for `attachTo` in favor of object

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ let tour = new Shepherd.Tour({
 tour.addStep('example', {
   title: 'Example Shepherd',
   text: 'Creating a Shepherd is easy too! Just create ...',
-  attachTo: '.hero-example bottom',
+  attachTo: {
+    element: '.hero-example',
+    on: 'bottom'
+  },
   advanceOn: {
     selector: '.docs-link',
     event: 'click'

--- a/docs/welcome/index.html
+++ b/docs/welcome/index.html
@@ -60,7 +60,10 @@
               title: 'Creating a Shepherd Tour',
               text: `Creating a Shepherd tour is easy. too!\
               Just create a \`Tour\` instance, and add as many steps as you want.`,
-              attachTo: '.hero-example bottom',
+              attachTo: {
+                element: '.hero-example',
+                on: 'bottom'
+              },
               buttons: [
                 {
                   action: shepherd.back,

--- a/docs/welcome/js/welcome.js
+++ b/docs/welcome/js/welcome.js
@@ -35,7 +35,10 @@
           as they enter and exit the view.
         `
       ],
-      attachTo: '.hero-welcome bottom',
+      attachTo: {
+        element: '.hero-welcome',
+        on: 'bottom'
+      },
       classes: 'shepherd shepherd-welcome',
       buttons: [
         {
@@ -51,7 +54,10 @@
     shepherd.addStep('including', {
       title: 'Including',
       text: 'Including Shepherd is easy! Just include tippy.all.min.js, shepherd.js, and a Shepherd theme file.',
-      attachTo: '.hero-including bottom',
+      attachTo: {
+        element: '.hero-including',
+        on: 'bottom'
+      },
       buttons: [
         {
           action: shepherd.back,
@@ -67,7 +73,10 @@
       title: 'Creating a Shepherd Tour',
       text: `Creating a Shepherd tour is easy. too!\
       Just create a \`Tour\` instance, and add as many steps as you want.`,
-      attachTo: '.hero-example bottom',
+      attachTo: {
+        element: '.hero-example',
+        on: 'bottom'
+      },
       buttons: [
         {
           action: shepherd.back,
@@ -83,7 +92,10 @@
     shepherd.addStep('attaching', {
       title: 'Attaching to Elements',
       text: `Your tour steps can target and attach to elements in DOM (like this step).`,
-      attachTo: '.hero-example bottom',
+      attachTo: {
+        element: '.hero-example',
+        on: 'bottom'
+      },
       buttons: [
         {
           action: shepherd.back,
@@ -116,7 +128,10 @@
     shepherd.addStep('followup', {
       title: 'Learn more',
       text: 'Star Shepherd on Github so you remember it for your next project',
-      attachTo: '.hero-followup top',
+      attachTo: {
+        element: '.hero-followup',
+        on: 'top'
+      },
       buttons: [
         {
           action: shepherd.back,

--- a/index.md
+++ b/index.md
@@ -66,7 +66,10 @@ Next, add your steps:
 ```javascript
 tour.addStep('example-step', {
   text: 'This step is attached to the bottom of the <code>.example-css-selector</code> element.',
-  attachTo: '.example-css-selector bottom',
+  attachTo: { 
+    element: '.example-css-selector', 
+    on: 'bottom'
+  },
   classes: 'example-step-extra-class',
   buttons: [
     {

--- a/src/eager/installHelper.js
+++ b/src/eager/installHelper.js
@@ -88,7 +88,10 @@
         title: step.title,
         text: step.text,
         showCancelLink: step.showCancelLink,
-        attachTo: `${step.attachToSelector} ${step.attachToDirection}`,
+        attachTo: {
+          element: step.attachToSelector,
+          on: step.attachToDirection
+        },
         classes: `shepherd-element shepherd-theme-${options.theme}`,
         scrollTo: options.scrollTo
       };

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -33,23 +33,17 @@ export class Step extends Evented {
    * @param {Tour} tour The tour for the step
    * @param {Object} options The options for the step
    * @param {Object|string} options.attachTo What element the step should be attached to on the page.
-   * It can either be a string of the form `[element] [on]` (where [element] is an element selector path):
-   * ```js
-   * const new Step(tour, {
-   *   attachTo: '.some .selector-path left',
-   *   ...moreOptions,
-   * })'
-   * ```
-   * Or an object with those properties:
+   * It should be an object with the properties `element` and `on`, where `element` is an element selector string
+   * or a DOM element and `on` is the optional direction to place the Tippy tooltip.
+   *
    * ```js
    * const new Step(tour, {
    *   attachTo: { element: '.some .selector-path', on: 'left' },
    *   ...moreOptions
    * })'
    * ```
-   * If you use the object syntax, element can also be a DOM element. If you don’t specify an attachTo the
-   * element will appear in the middle of the screen.
    *
+   * If you don’t specify an attachTo the element will appear in the middle of the screen.
    * If you omit the `on` portion of `attachTo`, the element will still be highlighted, but the tooltip will appear
    * in the middle of the screen, without an arrow pointing to the target.
    * @param {HTMLElement|string} options.attachTo.element

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -141,13 +141,13 @@ export function setupTooltip() {
 }
 
 /**
- * Passes `options.attachTo` to `_parseAttachToOpts` to get the correct `attachTo` format
+ * Checks if options.attachTo.element is a string, and if so, tries to find the element
  * @returns {({} & {element, on}) | ({})}
  * `element` is a qualified HTML Element
  * `on` is a string position value
  */
 export function parseAttachTo() {
-  const options = _parseAttachToOpts(this.options.attachTo) || {};
+  const options = this.options.attachTo || {};
   const returnOpts = Object.assign({}, options);
 
   if (isString(options.element)) {

--- a/test/cypress/integration/modal.spec.js
+++ b/test/cypress/integration/modal.spec.js
@@ -79,7 +79,10 @@ describe('Modal mode', () => {
         {
           id: 'test-highlight',
           options: {
-            attachTo: '.hero-welcome bottom',
+            attachTo: {
+              element:'.hero-welcome',
+              on:'bottom'
+            },
             highlightClass: 'highlight',
             text: 'Testing highlight'
           }

--- a/test/cypress/utils/default-steps.js
+++ b/test/cypress/utils/default-steps.js
@@ -18,7 +18,10 @@ export default function(shepherd) {
             as they enter and exit the view.
           `
         ],
-        attachTo: '.hero-welcome bottom',
+        attachTo: {
+          element: '.hero-welcome',
+          on: 'bottom'
+        },
         classes: 'shepherd-step-element shepherd-transparent-text first-step',
         buttons: [
           {
@@ -38,7 +41,10 @@ export default function(shepherd) {
       options: {
         title: 'Including',
         text: 'Including Shepherd is easy! Just include tippy.all.min.js, shepherd.js, and a Shepherd theme file.',
-        attachTo: '.hero-including bottom',
+        attachTo: {
+          element: '.hero-including',
+          on: 'bottom'
+        },
         buttons: [
           {
             action: shepherd.back,
@@ -58,7 +64,10 @@ export default function(shepherd) {
       options: {
         title: 'Example Shepherd',
         text: 'Creating a Shepherd is easy too! Just create Shepherd and add as many steps as you want. Check out the <a href="https://shipshapecode.github.io/shepherd/">documentation</a> to learn more.',
-        attachTo: '.hero-example bottom',
+        attachTo: {
+          element: '.hero-example',
+          on: 'bottom'
+        },
         buttons: [
           {
             action: shepherd.back,
@@ -78,7 +87,10 @@ export default function(shepherd) {
       options: {
         title: 'Learn more',
         text: 'Star Shepherd on Github so you remember it for your next project',
-        attachTo: '.hero-followup left',
+        attachTo: {
+          element:'.hero-followup',
+          on: 'left'
+        },
         buttons: [
           {
             action: shepherd.back,

--- a/test/dummy/index.html
+++ b/test/dummy/index.html
@@ -59,8 +59,14 @@
             tour.addStep('example', {
               title: 'Example Shepherd',
               text: 'Creating a Shepherd is easy too! Just create ...',
-              attachTo: '.hero-example bottom',
-              advanceOn: { selector: '.docs-link', event: 'click' }
+              attachTo: {
+                element: '.hero-example',
+                on: 'bottom'
+              },
+              advanceOn: {
+                selector: '.docs-link',
+                event: 'click'
+              }
             });
 
             tour.start();

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -20,7 +20,7 @@ describe('Tour | Step', () => {
     });
 
     const testStep = instance.addStep('test', {
-      attachTo: 'body',
+      attachTo: { element: 'body' },
       highlightClass: 'highlight',
       id: 'test-id',
       text: 'This is a step for testing',
@@ -49,7 +49,7 @@ describe('Tour | Step', () => {
     });
 
     const stepWithoutNameWithId = instance.addStep({
-      attachTo: 'body',
+      attachTo: { element: 'body' },
       highlightClass: 'highlight',
       id: 'no-name',
       text: 'This is a step without a name, but with an id',
@@ -62,7 +62,7 @@ describe('Tour | Step', () => {
     });
 
     const stepWithoutNameWithoutId = instance.addStep({
-      attachTo: 'body',
+      attachTo: { element:'body' },
       highlightClass: 'highlight',
       text: 'This is a step without a name, and without an id',
       buttons: [

--- a/test/unit/utils/cleanup.spec.js
+++ b/test/unit/utils/cleanup.spec.js
@@ -16,13 +16,19 @@ describe('Cleanup Utils', function() {
     steps: [
       {
         options: {
-          attachTo: '.first-attach-to bottom',
+          attachTo: {
+            element: '.first-attach-to',
+            on: 'bottom'
+          },
           canClickTarget: false
         }
       },
       {
         options: {
-          attachTo: '.second-attach-to bottom',
+          attachTo: {
+            element: '.second-attach-to',
+            on: 'bottom'
+          },
           canClickTarget: false
         }
       }

--- a/test/unit/utils/dom.spec.js
+++ b/test/unit/utils/dom.spec.js
@@ -45,19 +45,5 @@ describe('DOM Utils', function() {
 
       expect(getElementForStep(step), 'returns element from selector').toEqual(element);
     });
-
-    it('attachTo string', () => {
-      const element = document.createElement('div');
-      element.classList.add('foo');
-      document.body.appendChild(element);
-
-      const step = {
-        options: {
-          attachTo: '.foo bottom'
-        }
-      };
-
-      expect(getElementForStep(step), 'returns element from selector').toEqual(element);
-    });
   });
 });

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -13,14 +13,5 @@ describe('Utils', function() {
         .toEqual(attachTo);
       expect(_parseAttachToOpts({}), 'when attachTo does not include `element` and `on`, return null').toBeNull();
     });
-
-    it('attachTo as a string', function() {
-      let attachTo = '.foo bottom';
-      expect(_parseAttachToOpts(attachTo), 'when attachTo is a string, return as object with `element` and `on`')
-        .toEqual({ element: '.foo', on: 'bottom' });
-
-      attachTo = '.foo notValid';
-      expect(_parseAttachToOpts(attachTo), 'when `on` is not a valid direction, return null').toBe(null);
-    });
   });
 });


### PR DESCRIPTION
This will be a breaking change for anyone using the string format, but we wanted to start enforcing one and only one API for each thing, to both remove confusion, and lessen the burden of maintaining several formats.