### PR TITLE
Remove array support for `step.options.text`

### DIFF
--- a/docs/welcome/js/welcome.js
+++ b/docs/welcome/js/welcome.js
@@ -20,21 +20,21 @@
     });
 
     shepherd.addStep('welcome', {
-      text: [
-        `
-          Shepherd is a JavaScript library for guiding users through your app.
-          It uses <a href="https://atomiks.github.io/tippyjs//">Tippy.js</a>,
-          another open source library, to render dialogs for each tour "step".
-        `,
-        `
-          Among many things, Tippy makes sure your steps never end up off screen or cropped by an overflow.
-          (Try resizing your browser to see what we mean.)
-        `,
-        `
-          It also offers a robust API for styling animations of steps
-          as they enter and exit the view.
-        `
-      ],
+      text: `
+         <p>
+           Shepherd is a JavaScript library for guiding users through your app.
+           It uses <a href="https://atomiks.github.io/tippyjs//" data-test-tippy-link>Tippy.js</a>,
+           another open source library, to render dialogs for each tour "step".
+         </p>
+        
+         <p>
+           Among many things, Tippy makes sure your steps never end up off screen or cropped by an overflow.
+           (Try resizing your browser to see what we mean.)
+         </p>
+         <p>
+           It also offers a robust API for styling animations of steps
+           as they enter and exit the view.
+         </p>`,
       attachTo: {
         element: '.hero-welcome',
         on: 'bottom'

--- a/index.md
+++ b/index.md
@@ -187,11 +187,10 @@ created.
 
 ##### Step Options
 
-- `text`: The text in the body of the step.  It can be one of four types:
+- `text`: The text in the body of the step. It can be one of three types:
   - HTML string
-  - Array of HTML strings
   - `HTMLElement` object
-  - Function to be executed when the step is built. It must return one the three options above.
+  - `Function` to be executed when the step is built. It must return one the two options above.
 - `title`: The step's title. It becomes an `h3` at the top of the step.
 - `attachTo`: What element the step should be attached to on the page.
 It should be an object with the properties `element` and `on`, where `element` is an element selector string

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -1,4 +1,4 @@
-import { isElement, isFunction, isString, isUndefined } from './utils/type-check';
+import { isElement, isFunction, isUndefined } from './utils/type-check';
 import { Evented } from './evented.js';
 import { bindAdvance, bindButtonEvents, bindCancelLink, bindMethods } from './utils/bind.js';
 import { createFromHTML, setupTooltip, parseAttachTo } from './utils/general.js';
@@ -85,12 +85,11 @@ export class Step extends Evented {
    * @param {boolean} options.showCancelLink Should a cancel “✕” be shown in the header of the step?
    * @param {function} options.showOn A function that, when it returns `true`, will show the step.
    * If it returns false, the step will be skipped.
-   * @param {string} options.text The text in the body of the step. It can be one of four types:
+   * @param {string} options.text The text in the body of the step. It can be one of three types:
    * ```
    * - HTML string
-   * - Array of HTML strings
    * - `HTMLElement` object
-   * - `Function` to be executed when the step is built. It must return one of the three options above.
+   * - `Function` to be executed when the step is built. It must return one the two options above.
    * ```
    * @param {string} options.title The step's title. It becomes an `h3` at the top of the step.
    * @param {Object} options.when You can define `show`, `hide`, etc events inside `when`. For example:
@@ -326,30 +325,22 @@ export class Step extends Evented {
    * @private
    */
   _addContent(content, descriptionId) {
-    const text = createFromHTML(
+    const textContainer = createFromHTML(
       `<div class="shepherd-text"
        id="${descriptionId}"
        ></div>`
     );
-    let paragraphs = this.options.text;
 
-    if (isFunction(paragraphs)) {
-      paragraphs = paragraphs.call(this, text);
+    let { text } = this.options;
+
+    if (isFunction(text)) {
+      text = text.call(this, textContainer);
     }
 
-    if (paragraphs instanceof HTMLElement) {
-      text.appendChild(paragraphs);
-    } else {
-      if (isString(paragraphs)) {
-        paragraphs = [paragraphs];
-      }
+    // If the test is already and HTMLElement, we append it, if it is a string, we add it to `innerHTML`
+    isElement(text) ? textContainer.appendChild(text) : textContainer.innerHTML += text;
 
-      paragraphs.map((paragraph) => {
-        text.innerHTML += `<p>${paragraph}</p>`;
-      });
-    }
-
-    content.appendChild(text);
+    content.appendChild(textContainer);
   }
 
   /**

--- a/test/cypress/integration/test.acceptance.js
+++ b/test/cypress/integration/test.acceptance.js
@@ -26,7 +26,7 @@ describe('Shepherd Acceptance Tests', () => {
             {
               id: 'welcome',
               options: {
-                text: ['Shepherd is a JavaScript library'],
+                text: 'Shepherd is a JavaScript library',
                 attachTo: {
                   element: '.hero-welcome',
                   on: 'bottom'

--- a/test/cypress/utils/default-steps.js
+++ b/test/cypress/utils/default-steps.js
@@ -3,21 +3,21 @@ export default function(shepherd) {
     {
       id: 'welcome',
       options: {
-        text: [
-          `
-            Shepherd is a JavaScript library for guiding users through your app.
-            It uses <a href="https://atomiks.github.io/tippyjs//" data-test-tippy-link>Tippy.js</a>,
-            another open source library, to render dialogs for each tour "step".
-          `,
-          `
-            Among many things, Tippy makes sure your steps never end up off screen or cropped by an overflow.
-            (Try resizing your browser to see what we mean.)
-          `,
-          `
-            It also offers a robust API for styling animations of steps
-            as they enter and exit the view.
-          `
-        ],
+        text: `
+         <p>
+           Shepherd is a JavaScript library for guiding users through your app.
+           It uses <a href="https://atomiks.github.io/tippyjs//" data-test-tippy-link>Tippy.js</a>,
+           another open source library, to render dialogs for each tour "step".
+         </p>
+        
+         <p>
+           Among many things, Tippy makes sure your steps never end up off screen or cropped by an overflow.
+           (Try resizing your browser to see what we mean.)
+         </p>
+         <p>
+           It also offers a robust API for styling animations of steps
+           as they enter and exit the view.
+         </p>`,
         attachTo: {
           element: '.hero-welcome',
           on: 'bottom'

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -459,18 +459,7 @@ describe('Tour | Step', () => {
 
       step._addContent(content);
 
-      expect(content.querySelector('.shepherd-text p').innerHTML).toBe('I am some test text.');
-    });
-
-    it('maps mutiple strings to paragraphs', () => {
-      const content = document.createElement('div');
-      const step = new Step();
-      step.options.text = ['I am some test text.', 'I am even more test text.'];
-
-      step._addContent(content);
-      expect(content.querySelectorAll('.shepherd-text p').length).toBe(2);
-      expect(step.options.text.join(' '))
-        .toBe(Array.from(content.querySelectorAll('.shepherd-text p')).map((text) => text.innerHTML).join(' '));
+      expect(content.querySelector('.shepherd-text').innerHTML).toBe('I am some test text.');
     });
 
     it('applies HTML element directly to content', () => {
@@ -482,7 +471,7 @@ describe('Tour | Step', () => {
 
       step._addContent(content);
 
-      expect(content.querySelector('.shepherd-text p').innerHTML).toBe('I am some test text.');
+      expect(content.querySelector('.shepherd-text').innerHTML).toBe('<p>I am some test text.</p>');
     });
 
     it('applies the text from a function', () => {
@@ -493,7 +482,7 @@ describe('Tour | Step', () => {
       step._addContent(content);
 
       expect(typeof step.options.text === 'function').toBeTruthy();
-      expect(content.querySelector('.shepherd-text p').innerHTML).toBe('I am some test text.');
+      expect(content.querySelector('.shepherd-text').innerHTML).toBe('I am some test text.');
     });
   });
 


### PR DESCRIPTION
The array option wrapped each string in a `<p>`, but you can wrap them yourself, by using an HTML string, so it seemed redundant and confusing.