### PR TITLE
fix for incorrect types path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://shepherdjs.dev/demo/",
   "license": "MIT",
   "main": "dist/js/shepherd.js",
-  "types": "src/shepherd.d.ts",
+  "types": "src/types/shepherd.d.ts",
   "module": "dist/js/shepherd.esm.js",
   "dependencies": {
     "body-scroll-lock": "^2.6.3",


### PR DESCRIPTION
incorrect path to types file results in no intellisense or typing support

Fixes #435 