### PR TITLE
fix applying tippyOptions

### DIFF
--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -1,6 +1,5 @@
 import { isString, isUndefined } from './type-check';
 import tippy from 'tippy.js';
-import getVariables from '../styles/variables';
 
 const addHasTitleClass = (step) => {
   return { addHasTitleClass: _createClassModifier(`${step.classPrefix}shepherd-has-title`) };
@@ -183,10 +182,6 @@ function _makeAttachedTippyOptions(attachToOptions, step) {
     Object.assign(defaultPopperOptions.modifiers, addHasTitleClass(step));
   }
 
-  if (step.options.tippyOptions && step.options.tippyOptions.maxWidth) {
-    Object.assign(tippyOptions, step.options.tippyOptions.maxWidth);
-  }
-
   if (step.options.tippyOptions && step.options.tippyOptions.popperOptions) {
     Object.assign(defaultPopperOptions, step.options.tippyOptions.popperOptions);
   }
@@ -219,10 +214,6 @@ function _makeCenteredTippy(step) {
 
   if (step.options.title) {
     Object.assign(defaultPopperOptions.modifiers, addHasTitleClass(step));
-  }
-
-  if (step.options.tippyOptions && step.options.tippyOptions.maxWidth) {
-    Object.assign(tippyOptions, step.options.tippyOptions.maxWidth);
   }
 
   Object.assign(


### PR DESCRIPTION
tippy options are already applied at: https://github.com/shipshapecode/shepherd/blob/master/src/js/utils/general.js#L179

the deleted lines essentially do something like: 
```
Object.assign({a: 'hello', b: 'bye'}, '400px')
```
which results in:
```
{0: "4", 1: "0", 2: "0", 3: "p", 4: "x", a: "hello", b: "bye"}
```

getVariables import not used (there is error at compile time)