### PR TITLE
fix content border radius

### DIFF
--- a/src/js/components/shepherd-content/styles.js
+++ b/src/js/components/shepherd-content/styles.js
@@ -4,7 +4,8 @@ export default function contentStyles(variables) {
       background: variables.shepherdTextBackground,
       fontSize: 'inherit',
       outline: 'none',
-      padding: 0
+      padding: 0,
+      borderRadius: variables.shepherdElementBorderRadius
     }
   };
 }


### PR DESCRIPTION
at the moment `shepherdElementBorderRadius` has no effect on when `attachTo` is used. It works only for modal.
Because the radius is applied only to header and footer. applying it on content as well, fixes it.