### PR TITLE
Fix for the wrong type definition of StepOptions.scrollTo

### DIFF
--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -115,7 +115,7 @@ declare namespace Step {
     /**
      * Should the element be scrolled to when this step is shown?
      */
-    scrollTo?: boolean;
+    scrollTo?: boolean | ScrollIntoViewOptions;
 
     /**
      * A function that lets you override the default scrollTo behavior and


### PR DESCRIPTION
Simple fix for the wrong type definition of StepOptions.scrollTo property

Fixes #490