### PR TITLE
adding alt/role for image

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -100,7 +100,7 @@
       </p>
     </div>
     <div>
-      <img src="./sheep.svg"/>
+      <img src="./sheep.svg" alt="" role="presentation" />
     </div>
   </div>
 </div>


### PR DESCRIPTION
If merged, this PR would add the alt and role attribute to the decorative graphic at the bottom of the demo page. 

![image](https://user-images.githubusercontent.com/4587451/62873905-d9da3600-bce5-11e9-9017-8046c2013e0b.png)

