### PR TITLE
Remove Shepherd.Evented

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -259,26 +259,6 @@ yourApp.on('some-event', () => {
 });
 ```
 
-It's strongly recommended that you use some sort of event mediator to connect your app's actions with Shepherd, to prevent
-having to sprinkle Shepherd code throughout your codebase, and to keep things loosely coupled.  You can create a basic
-mediator if need be using the `Evented` object which is provided with Shepherd:
-
-```javascript
-const mediator = new Shepherd.Evented();
-```
-
-You can then trigger events in one part of your app:
-
-```javascript
-mediator.trigger('user-create');
-```
-
-And listen for them in other areas:
-
-```javascript
-mediator.on('user-create', () => {});
-```
-
 ### Rendering Tours in Specific Locations
 
 By default, tour steps will append their elements to the `body` element of the DOM. This is perfect for most use cases, but not always. If you need to have steps appended elsewhere you can take advantage of Tippy's

--- a/src/js/shepherd.js
+++ b/src/js/shepherd.js
@@ -1,9 +1,8 @@
 import 'es6-symbol/implement';
 
-import { Evented } from './evented';
 import { Step } from './step';
 import { Shepherd, Tour } from './tour';
 
-Object.assign(Shepherd, { Tour, Step, Evented });
+Object.assign(Shepherd, { Tour, Step });
 
 export default Shepherd;

--- a/yarn.lock
+++ b/yarn.lock
@@ -812,7 +812,7 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.2.0.tgz#079a133be240ff866ad8532eaa46a691bdd91117"
   integrity sha512-pR2ZgiP562aiaQvQ98WgfqfTrm+xG+7hwHRPEiYZ+7U1OHAAb4OVZJIalCP03bMqYSioQzflzVTVrybSwDBn1Q==
 
-"@hapi/joi@^15.0.3":
+"@hapi/joi@15.1.0", "@hapi/joi@^15.0.3":
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.0.tgz#940cb749b5c55c26ab3b34ce362e82b6162c8e7a"
   integrity sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==
@@ -3534,7 +3534,7 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@7.1.4, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -6807,12 +6807,14 @@ rollup-plugin-filesize@^6.2.0:
     gzip-size "^5.1.1"
     terser "^4.1.3"
 
-rollup-plugin-license@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-license/-/rollup-plugin-license-0.11.0.tgz#51a5ae68bb05ebf182c87ef205af002d2e3bf42f"
-  integrity sha512-0HcvWhCSJ6G5SQg8BOdLS/ic/51hz2XIUHb1fR8z/kqbbCpJUAZcZoq2EXIghfyccvtOak7rRxlh9VA4i6/lHA==
+rollup-plugin-license@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-license/-/rollup-plugin-license-0.12.0.tgz#eb8a707a4e53eb2248ba915d902cec8e296e5f0d"
+  integrity sha512-Wo+3FB37+CzSB2AdZb/Flk7gHnUZNJhBkGSYFL6v56/nNHJ76SgsxpgiFaUUlLBZ6vvIb3xA4xUZgp6ghhiAWQ==
   dependencies:
+    "@hapi/joi" "15.1.0"
     commenting "1.1.0"
+    glob "7.1.4"
     lodash "4.17.15"
     magic-string "0.25.3"
     mkdirp "0.5.1"


### PR DESCRIPTION
We no longer see a need to expose `Shepherd.Evented`. The events on tours and steps will continue to work. Since this was technically public API, this is a breaking change.