### PR TITLE
Add overlayOpacity to styleVariables options

### DIFF
--- a/docs-src/tutorials/03-styling.md
+++ b/docs-src/tutorials/03-styling.md
@@ -39,6 +39,8 @@ We use [polished](https://github.com/styled-components/polished) to calculate li
 
 | Variable                    | Purpose                                                            | Default
 |-----------------------------|--------------------------------------------------------------------|--------
+| arrowSize                   | Sets the scale of the arrow for the tooltip.                       | 2.1
+| overlayOpacity              | Sets the opacity of the modal overlay.                             | 0.5
 | shepherdElementBorderRadius | Sets the border-radius of the shepherd-element.                    | 5px
 | shepherdElementMaxHeight    | Maximum height of the element                                      | 100%
 | shepherdElementMaxWidth     | Maximum width of the element                                       | 100%

--- a/src/js/components/shepherd-modal/styles.js
+++ b/src/js/components/shepherd-modal/styles.js
@@ -1,4 +1,4 @@
-export default function modalStyles(classPrefix) {
+export default function modalStyles(classPrefix, variables) {
   return {
     'modal-overlay-container': {
       '-ms-filter': 'progid:dximagetransform.microsoft.gradient.alpha(Opacity=50)',
@@ -14,7 +14,7 @@ export default function modalStyles(classPrefix) {
       zIndex: 9997,
       [`.${classPrefix}shepherd-modal-is-visible &`]: {
         height: '100vh',
-        opacity: '0.5',
+        opacity: variables.overlayOpacity,
         transition: 'all 0.3s ease-out, height 0s 0s, opacity 0.3s 0s'
       }
     },

--- a/src/js/styles/generateStyles.js
+++ b/src/js/styles/generateStyles.js
@@ -37,7 +37,7 @@ export function generateStyles(options) {
     ...elementStyles(),
     ...footerStyles(classPrefix, variables),
     ...headerStyles(classPrefix, variables),
-    ...modalStyles(classPrefix),
+    ...modalStyles(classPrefix, variables),
     ...textStyles(variables)
   };
 

--- a/src/js/styles/variables.js
+++ b/src/js/styles/variables.js
@@ -2,6 +2,7 @@ import { darken, desaturate, lighten, readableColor, transparentize } from 'poli
 
 const styles = {
   arrowSize: 2.1,
+  overlayOpacity: 0.5,
   shepherdButtonBorderRadius: '3px',
   shepherdElementBorderRadius: '5px',
   shepherdElementMaxHeight: '100%',


### PR DESCRIPTION
This will allow for setting the opacity of the overlay, more easily, rather than defaulting to 0.5.