### PR TITLE
Remove object-assign-deep, refactor setting popper options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'complexity': ['warn', 6],
     'max-lines': ['warn', { max: 250, skipBlankLines: true, skipComments: true }],
     'no-console': 'off',
+    'prefer-const': 'off',
     'react/jsx-tag-spacing': 'off'
   },
   overrides: [

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "es6-object-assign": "^1.1.0",
     "es6-symbol": "^3.1.1",
     "nano-css": "^5.2.0",
-    "object-assign-deep": "^0.4.0",
     "polished": "^3.4.1",
     "preact": "^8.5.1",
     "smoothscroll-polyfill": "^0.4.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ const plugins = [
   commonjs(),
   eslint(),
   babel({
-    exclude: /node_modules\/(?!(nano-css|object-assign-deep)\/).*/
+    exclude: /node_modules\/(?!(nano-css)\/).*/
   }),
   replace({
     'process.env.NODE_ENV': JSON.stringify(env)
@@ -102,7 +102,7 @@ if (!process.env.DEVELOPMENT) {
         }),
         commonjs(),
         babel({
-          exclude: /node_modules\/(?!(nano-css|object-assign-deep)\/).*/
+          exclude: /node_modules\/(?!(nano-css)\/).*/
         }),
         replace({
           'process.env.NODE_ENV': JSON.stringify(env)

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -1,5 +1,4 @@
 import { isString, isUndefined } from './type-check';
-import objectAssignDeep from 'object-assign-deep';
 import tippy from 'tippy.js';
 
 const addHasTitleClass = (step) => {
@@ -149,15 +148,29 @@ function _makeAttachedTippyOptions(attachToOptions, step) {
     ...step.options.tippyOptions
   };
 
+  let popperModifiers = defaultPopperOptions.modifiers;
+  let popperOptions = defaultPopperOptions;
+
   if (step.options.title) {
-    objectAssignDeep(defaultPopperOptions.modifiers, addHasTitleClass(step));
+    popperModifiers = {
+      ...popperModifiers,
+      ...addHasTitleClass(step)
+    };
   }
 
   if (step.options.tippyOptions && step.options.tippyOptions.popperOptions) {
-    objectAssignDeep(defaultPopperOptions, step.options.tippyOptions.popperOptions);
+    popperModifiers = {
+      ...popperModifiers,
+      ...step.options.tippyOptions.popperOptions.modifiers
+    };
+    popperOptions = {
+      ...popperOptions,
+      ...step.options.tippyOptions.popperOptions
+    };
+    popperOptions.modifiers = popperModifiers;
   }
 
-  tippyOptions.popperOptions = defaultPopperOptions;
+  tippyOptions.popperOptions = popperOptions;
 
   return tippyOptions;
 }
@@ -183,23 +196,26 @@ function _makeCenteredTippy(step) {
   tippyOptions.arrow = false;
   tippyOptions.popperOptions = tippyOptions.popperOptions || {};
 
+  let popperModifiers = defaultPopperOptions.modifiers;
+  const popperOptions = {
+    ...defaultPopperOptions,
+    ...tippyOptions.popperOptions
+  };
+
   if (step.options.title) {
-    objectAssignDeep(defaultPopperOptions.modifiers, addHasTitleClass(step));
+    popperModifiers = {
+      ...popperModifiers,
+      ...addHasTitleClass(step)
+    };
   }
 
-  objectAssignDeep(
-    defaultPopperOptions.modifiers,
-    centeredStylePopperModifier,
-    tippyOptions.popperOptions.modifiers
-  );
-
-  const finalPopperOptions = objectAssignDeep(
-    {},
-    defaultPopperOptions,
-    tippyOptions.popperOptions
-  );
-
-  tippyOptions.popperOptions = finalPopperOptions;
+  popperModifiers = {
+    ...popperModifiers,
+    ...centeredStylePopperModifier,
+    ...tippyOptions.popperOptions.modifiers
+  };
+  popperOptions.modifiers = popperModifiers;
+  tippyOptions.popperOptions = popperOptions;
 
   return tippy(document.body, tippyOptions);
 }

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -167,9 +167,9 @@ function _makeAttachedTippyOptions(attachToOptions, step) {
       ...popperOptions,
       ...step.options.tippyOptions.popperOptions
     };
-    popperOptions.modifiers = popperModifiers;
   }
-
+  
+  popperOptions.modifiers = popperModifiers;
   tippyOptions.popperOptions = popperOptions;
 
   return tippyOptions;

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -168,7 +168,7 @@ function _makeAttachedTippyOptions(attachToOptions, step) {
       ...step.options.tippyOptions.popperOptions
     };
   }
-  
+
   popperOptions.modifiers = popperModifiers;
   tippyOptions.popperOptions = popperOptions;
 

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -1,40 +1,6 @@
+import { makeAttachedTippyOptions, makeCenteredTippy } from './tippy-popper-options';
 import { isString, isUndefined } from './type-check';
 import tippy from 'tippy.js';
-
-const addHasTitleClass = (step) => {
-  return { addHasTitleClass: _createClassModifier(`${step.classPrefix}shepherd-has-title`) };
-};
-
-function _getCenteredStylePopperModifier(styles) {
-  return {
-    computeStyle: {
-      enabled: true,
-      fn(data) {
-        data.styles = Object.assign({}, data.styles, {
-          left: '50%',
-          top: '50%',
-          transform: 'translate(-50%, -50%)'
-        });
-
-        return data;
-      }
-    },
-    addShepherdClass: _createClassModifier(styles.shepherd.trim())
-  };
-}
-
-/**
- * Used to compose settings for tippyOptions.popperOptions (https://atomiks.github.io/tippyjs/#popper-options-option)
- * @private
- */
-function _getDefaultPopperOptions(styles) {
-  return {
-    positionFixed: true,
-    modifiers: {
-      addShepherdClass: _createClassModifier(styles.shepherd.trim())
-    }
-  };
-}
 
 /**
  * Ensure class prefix ends in `-`
@@ -98,22 +64,6 @@ export function setupTooltip(step) {
 }
 
 /**
- * Create a popper modifier for adding the passed className to the popper
- * @param {string} className The class to add to the popper
- * @return {{fn(*): *, enabled: boolean}|*}
- * @private
- */
-function _createClassModifier(className) {
-  return {
-    enabled: true,
-    fn(data) {
-      data.instance.popper.classList.add(className);
-      return data;
-    }
-  };
-}
-
-/**
  * Generates a `Tippy` instance from a set of base `attachTo` options
  * @param attachToOptions
  * @param {Step} step The step instance
@@ -121,101 +71,16 @@ function _createClassModifier(className) {
  * @private
  */
 function _makeTippyInstance(attachToOptions, step) {
+  let tippyOptions = {};
+  let element = document.body;
+
   if (!attachToOptions.element || !attachToOptions.on) {
-    return _makeCenteredTippy(step);
+    tippyOptions = makeCenteredTippy(step);
+  } else {
+    tippyOptions = makeAttachedTippyOptions(attachToOptions, step);
+    element = attachToOptions.element;
   }
 
-  const tippyOptions = _makeAttachedTippyOptions(attachToOptions, step);
-
-  return tippy(attachToOptions.element, tippyOptions);
+  return tippy(element, tippyOptions);
 }
 
-/**
- * Generates the hash of options that will be passed to `Tippy` instances
- * target an element in the DOM.
- *
- * @param {Object} attachToOptions The local `attachTo` options
- * @param {Step} step The step instance
- * @return {Object} The final tippy options  object
- * @private
- */
-function _makeAttachedTippyOptions(attachToOptions, step) {
-  const defaultPopperOptions = _getDefaultPopperOptions(step.styles);
-  const tippyOptions = {
-    content: step.el,
-    flipOnUpdate: true,
-    placement: attachToOptions.on || 'right',
-    ...step.options.tippyOptions
-  };
-
-  let popperModifiers = defaultPopperOptions.modifiers;
-  let popperOptions = defaultPopperOptions;
-
-  if (step.options.title) {
-    popperModifiers = {
-      ...popperModifiers,
-      ...addHasTitleClass(step)
-    };
-  }
-
-  if (step.options.tippyOptions && step.options.tippyOptions.popperOptions) {
-    popperModifiers = {
-      ...popperModifiers,
-      ...step.options.tippyOptions.popperOptions.modifiers
-    };
-    popperOptions = {
-      ...popperOptions,
-      ...step.options.tippyOptions.popperOptions
-    };
-  }
-
-  popperOptions.modifiers = popperModifiers;
-  tippyOptions.popperOptions = popperOptions;
-
-  return tippyOptions;
-}
-
-/**
- * Generates a `Tippy` instance for a tooltip that doesn't have a
- * target element in the DOM -- and thus is positioned in the center
- * of the view
- *
- * @param {Step} step The step instance
- * @return {tippy} The final tippy instance
- * @private
- */
-function _makeCenteredTippy(step) {
-  const centeredStylePopperModifier = _getCenteredStylePopperModifier(step.styles);
-  const defaultPopperOptions = _getDefaultPopperOptions(step.styles);
-  const tippyOptions = {
-    content: step.el,
-    placement: 'top',
-    ...step.options.tippyOptions
-  };
-
-  tippyOptions.arrow = false;
-  tippyOptions.popperOptions = tippyOptions.popperOptions || {};
-
-  let popperModifiers = defaultPopperOptions.modifiers;
-  const popperOptions = {
-    ...defaultPopperOptions,
-    ...tippyOptions.popperOptions
-  };
-
-  if (step.options.title) {
-    popperModifiers = {
-      ...popperModifiers,
-      ...addHasTitleClass(step)
-    };
-  }
-
-  popperModifiers = {
-    ...popperModifiers,
-    ...centeredStylePopperModifier,
-    ...tippyOptions.popperOptions.modifiers
-  };
-  popperOptions.modifiers = popperModifiers;
-  tippyOptions.popperOptions = popperOptions;
-
-  return tippy(document.body, tippyOptions);
-}

--- a/src/js/utils/tippy-popper-options.js
+++ b/src/js/utils/tippy-popper-options.js
@@ -1,0 +1,126 @@
+const addHasTitleClass = (step) => {
+  return { addHasTitleClass: _createClassModifier(`${step.classPrefix}shepherd-has-title`) };
+};
+
+/**
+ * Create a popper modifier for adding the passed className to the popper
+ * @param {string} className The class to add to the popper
+ * @return {{fn(*): *, enabled: boolean}|*}
+ * @private
+ */
+function _createClassModifier(className) {
+  return {
+    enabled: true,
+    fn(data) {
+      data.instance.popper.classList.add(className);
+      return data;
+    }
+  };
+}
+
+function _getCenteredStylePopperModifier(styles) {
+  return {
+    computeStyle: {
+      enabled: true,
+      fn(data) {
+        data.styles = Object.assign({}, data.styles, {
+          left: '50%',
+          top: '50%',
+          transform: 'translate(-50%, -50%)'
+        });
+
+        return data;
+      }
+    },
+    addShepherdClass: _createClassModifier(styles.shepherd.trim())
+  };
+}
+
+/**
+ * Used to compose settings for tippyOptions.popperOptions (https://atomiks.github.io/tippyjs/#popper-options-option)
+ * @private
+ */
+function _getDefaultPopperOptions(styles) {
+  return {
+    positionFixed: true,
+    modifiers: {
+      addShepherdClass: _createClassModifier(styles.shepherd.trim())
+    }
+  };
+}
+
+/**
+ * Generates the hash of options that will be passed to `Tippy` instances
+ * target an element in the DOM.
+ *
+ * @param {Object} attachToOptions The local `attachTo` options
+ * @param {Step} step The step instance
+ * @return {Object} The final tippy options object
+ */
+export function makeAttachedTippyOptions(attachToOptions, step) {
+  let { popperOptions, tippyOptions } = _makeCommonTippyOptions(step);
+
+  tippyOptions.flipOnUpdate = true;
+  tippyOptions.placement = attachToOptions.on || 'right';
+
+  if (step.options.tippyOptions && step.options.tippyOptions.popperOptions) {
+    popperOptions = {
+      ...popperOptions,
+      ...step.options.tippyOptions.popperOptions
+    };
+  }
+
+  tippyOptions.popperOptions = popperOptions;
+
+  return tippyOptions;
+}
+
+/**
+ * Generates the hash of options for a tooltip that doesn't have a
+ * target element in the DOM -- and thus is positioned in the center
+ * of the view
+ *
+ * @param {Step} step The step instance
+ * @return {Object} The final tippy options object
+ */
+export function makeCenteredTippy(step) {
+  const centeredStylePopperModifier = _getCenteredStylePopperModifier(step.styles);
+  let { popperOptions, tippyOptions } = _makeCommonTippyOptions(step);
+
+  tippyOptions.placement = 'top';
+  tippyOptions.arrow = false;
+  tippyOptions.popperOptions = tippyOptions.popperOptions || {};
+
+  popperOptions.modifiers = {
+    ...popperOptions.modifiers,
+    ...centeredStylePopperModifier,
+    ...tippyOptions.popperOptions.modifiers
+  };
+
+  popperOptions = {
+    ...popperOptions,
+    ...tippyOptions.popperOptions
+  };
+
+  tippyOptions.popperOptions = popperOptions;
+
+  return tippyOptions;
+}
+
+function _makeCommonTippyOptions(step) {
+  const popperOptions = _getDefaultPopperOptions(step.styles);
+
+  const tippyOptions = {
+    content: step.el,
+    ...step.options.tippyOptions
+  };
+
+  if (step.options.title) {
+    popperOptions.modifiers = {
+      ...popperOptions.modifiers,
+      ...addHasTitleClass(step)
+    };
+  }
+
+  return { popperOptions, tippyOptions };
+}

--- a/test/unit/utils/bind.spec.js
+++ b/test/unit/utils/bind.spec.js
@@ -1,7 +1,6 @@
 import { bindAdvance } from '../../../src/js/utils/bind.js';
 import { Step } from '../../../src/js/step.jsx';
 import { spy } from 'sinon';
-import { Tour } from '../../../src/js/tour';
 
 describe('Bind Utils', function() {
   describe('bindAdvance()', () => {

--- a/test/unit/utils/tippy-popper-options.spec.js
+++ b/test/unit/utils/tippy-popper-options.spec.js
@@ -1,0 +1,34 @@
+import { makeAttachedTippyOptions } from '../../../src/js/utils/tippy-popper-options';
+
+describe('Tippy/Popper Options Utils', function() {
+  describe('makeAttachedTippyOptions()', function() {
+    it('passing tippyOptions.popperOptions sets nested values', function() {
+      const stepOptions =
+        {
+          options: {
+            tippyOptions: {
+              popperOptions: {
+                modifiers: {
+                  foo: 'bar',
+                  preventOverflow: {
+                    escapeWithReference: true
+                  }
+                }
+              }
+            }
+          },
+          styles: {
+            shepherd: ' shepherd'
+          }
+        };
+
+      const attachToOpts = {
+        on: 'top'
+      };
+
+      const tippyOptions = makeAttachedTippyOptions(attachToOpts, stepOptions);
+      expect(tippyOptions.popperOptions.modifiers.foo).toBe('bar');
+      expect(tippyOptions.popperOptions.modifiers.preventOverflow.escapeWithReference).toBe(true);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5617,11 +5617,6 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign-deep@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/object-assign-deep/-/object-assign-deep-0.4.0.tgz#43505d3679abb9686ab359b97ac14cc837a9d143"
-  integrity sha512-54Uvn3s+4A/cMWx9tlRez1qtc7pN7pbQ+Yi7mjLjcBpWLlP+XbSHiHbQW6CElDiV4OvuzqnMrBdkgxI1mT8V/Q==
-
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"


### PR DESCRIPTION
Following https://github.com/shipshapecode/shepherd/pull/488

using 1K object-assign-deep seems overkill.

especially since their readme starts with: "Caution! Danger of Death!"
It introduces unnecessary risk fo user error.