### PR TITLE
Remove style vendor prefixing

### DIFF
--- a/src/js/styles/nano.js
+++ b/src/js/styles/nano.js
@@ -3,7 +3,6 @@ import { h } from 'preact';
 import { create } from 'nano-css';
 import { addon as addonCache } from 'nano-css/addon/cache';
 import { addon as addonNesting } from 'nano-css/addon/nesting';
-import { addon as prefixer } from 'nano-css/addon/prefixer';
 import { addon as addonRule } from 'nano-css/addon/rule';
 import { addon as addonSheet } from 'nano-css/addon/sheet';
 
@@ -15,7 +14,6 @@ const nano = create({
 
 addonCache(nano);
 addonNesting(nano);
-prefixer(nano);
 addonRule(nano);
 addonSheet(nano);
 


### PR DESCRIPTION
We do not seem to need any prefixing of our styles, as everything still works fine in IE. Removing it saves us ~3 kb min + gzip.

This is technically a breaking change, since someone could have been relying on vendor prefixing somewhere.