### PR TITLE
remove rarely used get-value dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "element-matches": "^0.1.2",
     "es6-object-assign": "^1.1.0",
     "es6-symbol": "^3.1.1",
-    "get-value": "^3.0.1",
     "nano-css": "^5.2.0",
     "polished": "^3.4.1",
     "preact": "^8.5.2",

--- a/src/js/step.jsx
+++ b/src/js/step.jsx
@@ -1,4 +1,3 @@
-import get from 'get-value';
 import preact from 'preact';
 
 import { Evented } from './evented';
@@ -229,12 +228,11 @@ export class Step extends Evented {
    * @private
    */
   _createTooltipContent() {
-    const cancelIconEnabled = get(this, 'options.cancelIcon.enabled');
     let classes = this.options.classes || '';
     const descriptionId = `${this.id}-description`;
     const labelId = `${this.id}-label`;
 
-    if (cancelIconEnabled) {
+    if (this.options.cancelIcon && this.options.cancelIcon.enabled) {
       classes += ` ${this.classPrefix}shepherd-has-cancel-icon`;
     }
 

--- a/src/js/utils/tippy-popper-options.js
+++ b/src/js/utils/tippy-popper-options.js
@@ -1,5 +1,3 @@
-import get from 'get-value';
-
 const addHasTitleClass = (step) => {
   return { addHasTitleClass: _createClassModifier(`${step.classPrefix}shepherd-has-title`) };
 };
@@ -65,9 +63,9 @@ export function makeAttachedTippyOptions(attachToOptions, step) {
   tippyOptions.flipOnUpdate = true;
   tippyOptions.placement = attachToOptions.on || 'right';
 
-  const stepPopperOptions = get(step, 'options.tippyOptions.popperOptions');
+  if (step.options.tippyOptions && step.options.tippyOptions.popperOptions) {
+    const stepPopperOptions = step.options.tippyOptions.popperOptions;
 
-  if (stepPopperOptions) {
     popperOptions = {
       ...popperOptions,
       ...stepPopperOptions,
@@ -122,10 +120,8 @@ function _makeCommonTippyOptions(step) {
     ...step.options.tippyOptions
   };
 
-  const shepherdElementZIndex = get(step, 'tour.options.styleVariables.shepherdElementZIndex');
-
-  if (shepherdElementZIndex) {
-    tippyOptions.zIndex = shepherdElementZIndex;
+  if (step.tour.options.styleVariables && (typeof step.tour.options.styleVariables.shepherdElementZIndex === 'number')) {
+    tippyOptions.zIndex = step.tour.options.styleVariables.shepherdElementZIndex;
   }
 
   if (step.options.title) {

--- a/test/unit/utils/tippy-popper-options.spec.js
+++ b/test/unit/utils/tippy-popper-options.spec.js
@@ -1,32 +1,29 @@
 import { makeAttachedTippyOptions } from '../../../src/js/utils/tippy-popper-options';
+import { Step } from '../../../src/js/step.jsx';
+import { Tour } from '../../../src/js/tour.jsx';
 
 describe('Tippy/Popper Options Utils', function() {
   describe('makeAttachedTippyOptions()', function() {
     it('passing tippyOptions.popperOptions sets nested values', function() {
-      const stepOptions =
-        {
-          options: {
-            tippyOptions: {
-              popperOptions: {
-                modifiers: {
-                  foo: 'bar',
-                  preventOverflow: {
-                    escapeWithReference: true
-                  }
-                }
+      const tour = new Tour();
+      const step = new Step(tour, {
+        tippyOptions: {
+          popperOptions: {
+            modifiers: {
+              foo: 'bar',
+              preventOverflow: {
+                escapeWithReference: true
               }
             }
-          },
-          styles: {
-            shepherd: ' shepherd'
           }
-        };
+        }
+      });
 
       const attachToOpts = {
         on: 'top'
       };
 
-      const tippyOptions = makeAttachedTippyOptions(attachToOpts, stepOptions);
+      const tippyOptions = makeAttachedTippyOptions(attachToOpts, step);
       expect(tippyOptions.popperOptions.modifiers.foo).toBe('bar');
       expect(tippyOptions.popperOptions.modifiers.preventOverflow.escapeWithReference).toBe(true);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3603,13 +3603,6 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-get-value@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/get-value/-/get-value-3.0.1.tgz#5efd2a157f1d6a516d7524e124ac52d0a39ef5a8"
-  integrity sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==
-  dependencies:
-    isobject "^3.0.1"
-
 getos@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/getos/-/getos-3.1.1.tgz#967a813cceafee0156b0483f7cffa5b3eff029c5"


### PR DESCRIPTION
the get-value is used 3 times and for trivial if checks.
removing it saves ~1K, most likely better performance (since simple if is used instead of get-value generic logic).
And finally less prone for errors, using strings for getting properties is not safe and cancels any autocompletion and typing.

(no new/change in functionality, so existing tests should cover the fix)