### PR TITLE
Fix tab focus when there are no focusable elements

### DIFF
--- a/src/js/components/shepherd-element/index.jsx
+++ b/src/js/components/shepherd-element/index.jsx
@@ -69,11 +69,6 @@ export default class ShepherdElement extends Component {
           e.preventDefault();
           break;
         }
-        if (this.focusableElements.length === 1) {
-          e.preventDefault();
-          this.firstFocusableElement.focus();
-          break;
-        }
         // Backward tab
         if (e.shiftKey) {
           if (document.activeElement === this.firstFocusableElement) {

--- a/src/js/components/shepherd-element/index.jsx
+++ b/src/js/components/shepherd-element/index.jsx
@@ -67,6 +67,7 @@ export default class ShepherdElement extends Component {
       case KEY_TAB:
         if (this.focusableElements.length === 1) {
           e.preventDefault();
+          this.firstFocusableElement.focus();
           break;
         }
         // Backward tab

--- a/src/js/components/shepherd-element/index.jsx
+++ b/src/js/components/shepherd-element/index.jsx
@@ -65,6 +65,10 @@ export default class ShepherdElement extends Component {
     const { tour } = this.step;
     switch (e.keyCode) {
       case KEY_TAB:
+        if (this.focusableElements.length === 0) {
+          e.preventDefault();
+          break;
+        }
         if (this.focusableElements.length === 1) {
           e.preventDefault();
           this.firstFocusableElement.focus();


### PR DESCRIPTION
The issue:
if a step contains only 1 focusable element clicking on TAB does not focus on it, the focus stays on the step element.

This fix will focus on the first element and keep the focus on it for subsequent tabs.

If I'm not mistaken, to add cypress a11 test for it, we need to change the welcome tour, since there is no step with single focusable element. Not sure you want to do it, so leave it to you.

[The second commit](https://github.com/shipshapecode/shepherd/pull/532/commits/7479441b0e8f2d4b326d6448430795de19cbbb37) handles another related issue: If there are no focusable elements, pressing TAB will move the focus outside of the tour.
I'm guessing we want to keep it inside. @rwwagner90  What do you think?
