### PR TITLE
Remove `disableScroll` option

### DIFF
--- a/docs-src/tutorials/04-cookbook.md
+++ b/docs-src/tutorials/04-cookbook.md
@@ -1,0 +1,7 @@
+### Disable Scroll
+
+Previously, disabling scrolling was built into Shepherd, but it was buggy
+and bulky, so we opted to remove [body-scroll-lock](https://github.com/willmcpo/body-scroll-lock) 
+as a dependency, in favor of users installing it directly in their apps. To disable scrolling, 
+you can install `body-scroll-lock` and run `bodyScrollLock.disableBodyScroll();` before
+starting the tour, then `bodyScrollLock.clearAllBodyScrollLocks();` after stopping the tour.

--- a/docs-src/tutorials/config.json
+++ b/docs-src/tutorials/config.json
@@ -7,5 +7,8 @@
   },
   "03-styling": {
     "title": "Theming and Styling"
+  },
+  "04-cookbook": {
+    "title": "Cookbook"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "types": "src/types/shepherd.d.ts",
   "module": "dist/js/shepherd.esm.js",
   "dependencies": {
-    "body-scroll-lock": "^2.6.4",
     "element-matches": "^0.1.2",
     "es6-object-assign": "^1.1.0",
     "es6-symbol": "^3.1.1",

--- a/src/js/tour.jsx
+++ b/src/js/tour.jsx
@@ -1,4 +1,3 @@
-import bodyScrollLock from 'body-scroll-lock';
 import preact from 'preact';
 import tippy from 'tippy.js';
 
@@ -40,8 +39,6 @@ export class Tour extends Evented {
    * @param {string} options.confirmCancelMessage The message to display in the confirm dialog
    * @param {string} options.classPrefix The prefix to add to all the `shepherd-*` class names.
    * @param {Object} options.defaultStepOptions Default options for Steps ({@link Step#constructor}), created through `addStep`
-   * @param {boolean} options.disableScroll When set to true, will keep the user from scrolling with the scrollbar,
-   * mousewheel, arrow keys, etc. You may want to use this to ensure you are driving the scroll position with the tour.
    * @param {boolean} options.exitOnEsc Exiting the tour with the escape key will be enabled unless this is explicitly
    * set to false.
    * @param {boolean} options.includeStyles If false, the majority of the Shepherd styles will not be included.
@@ -284,10 +281,6 @@ export class Tour extends Evented {
   start() {
     this.trigger('start');
 
-    if (this.options.disableScroll) {
-      bodyScrollLock.disableBodyScroll();
-    }
-
     // Save the focused element before the tour opens
     this.focusedElBeforeOpen = document.activeElement;
 
@@ -314,10 +307,6 @@ export class Tour extends Evented {
     Shepherd.activeTour = null;
     this._removeBodyAttrs();
     this.trigger('inactive', { tour: this });
-
-    if (this.options.disableScroll) {
-      bodyScrollLock.clearAllBodyScrollLocks();
-    }
 
     this.modal.hide();
 

--- a/src/types/tour.d.ts
+++ b/src/types/tour.d.ts
@@ -111,12 +111,6 @@ declare namespace Tour {
     defaultStepOptions?: Step.StepOptions;
 
     /**
-     * When set to true, will keep the user from scrolling with the scrollbar,
-     * mousewheel, arrow keys, etc. You may want to use this to ensure you are driving the scroll position with the tour.
-     */
-    disableScroll?: boolean;
-
-    /**
      * Exiting the tour with the escape key will be enabled unless this is explicitly
      * set to false.
      */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1698,11 +1698,6 @@ bluebird@3.5.5, bluebird@^3.5.4:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
   integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
-body-scroll-lock@^2.6.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-2.6.4.tgz#567abc60ef4d656a79156781771398ef40462e94"
-  integrity sha512-NP08WsovlmxEoZP9pdlqrE+AhNaivlTrz9a0FF37BQsnOrpN48eNqivKkE7SYpM9N+YIPjsdVzfLAUQDBm6OQw==
-
 bowser@^1.7.3:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
@@ -2832,9 +2827,9 @@ es-to-primitive@^1.2.0:
     is-symbol "^1.0.2"
 
 es5-ext@^0.10.35, es5-ext@^0.10.50, es5-ext@~0.10.14:
-  version "0.10.50"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.50.tgz#6d0e23a0abdb27018e5ac4fd09b412bc5517a778"
-  integrity sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==
+  version "0.10.51"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.51.tgz#ed2d7d9d48a12df86e0299287e93a09ff478842f"
+  integrity sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==
   dependencies:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"


### PR DESCRIPTION
disableScroll was buggy, and bulky, so removing in favor of users adding body-scroll-lock, or something similar directly in their apps. Added a cookbook entry to mention what to do.