### PR TITLE
Add ruby framework wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ A React wrapper for the site tour library Shepherd
 
 A Vue wrapper for the site tour library Shepherd
 
+### Ruby Framework Wrappers
+
+### [intro](https://github.com/jinhucheung/intro)
+
+A Rails engine that it injects dynamically-generated Shepherd code into Rails application
+
 ### Websites and Apps
 
 ### [SimplePlanner](https://simpleplanner.io)


### PR DESCRIPTION
Hi Shepherd,

I have a ruby library built on Shepherd. It  brings rails application to new feature introduction and step-by-step users guide.

Would I can add the [intro](https://github.com/jinhucheung/intro) to README?

Jim Cheung
Thank a lot