### PR TITLE
Add failing test for multiple tours and SVG overlay

### DIFF
--- a/test/unit/tour.spec.js
+++ b/test/unit/tour.spec.js
@@ -394,4 +394,17 @@ describe('Tour | Top-Level Class', function() {
       });
     });
   });
+
+  describe('multiple Tours', function() {
+    it('only creates one SVG overlay', function() {
+      instance = new Shepherd.Tour({
+        tourName: 'firstTour'
+      });
+      new Shepherd.Tour({
+        tourName: 'secondTour'
+      });
+
+      expect(document.querySelectorAll('.shepherd-modal-overlay-container').length).toEqual(1);
+    });
+  });
 });


### PR DESCRIPTION
```
[chuckcarpenter:~/Projects/shepherd]$ ./node_modules/.bin/jest -t 'multiple Tours'
 FAIL  test/unit/tour.spec.js
  ● Tour | Top-Level Class › multiple Tours › only creates one SVG overlay

    expect(received).toEqual(expected) // deep equality

    Expected: 1
    Received: 2

      405 |       });
      406 |
    > 407 |       expect(document.querySelectorAll('.shepherd-modal-overlay-container').length).toEqual(1);
          |                                                                                     ^
      408 |     });
      409 |   });
      410 | });

      at Object.toEqual (test/unit/tour.spec.js:407:85)

Test Suites: 1 failed, 11 skipped, 1 of 12 total
Tests:       1 failed, 82 skipped, 83 total
Snapshots:   0 total
Time:        3.426s, estimated 4s
Ran all test suites with tests matching "multiple Tours".
```