### PR TITLE
Add abraham project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ A React wrapper for the site tour library Shepherd
 
 A Vue wrapper for the site tour library Shepherd
 
+### Rails gems
+
+### [abraham](https://github.com/actmd/abraham)
+
+Rails engine that generates and tracks Shepherd tours within an application
+
 ### Websites and Apps
 
 ### [SimplePlanner](https://simpleplanner.io)


### PR DESCRIPTION
Originally released in 2016, [abraham](https://github.com/actmd/abraham) is a Rails engine that generates Shepherd tours and tracks whether users have completed them. Today, the abraham v2 release offers Shepherd v6 support.

(Thanks for keeping Shepherd going, the Rails community appreciates it!)