### PR TITLE
Removed unnecessary parenthetical commas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ to contribute, we ask that you take the following steps:
 
 ## Testing
 
-All PRs, that change code functionality, are required to have accompanying tests.
+All PRs that change code functionality are required to have accompanying tests.
 
 ### Acceptance Tests
 


### PR DESCRIPTION
I removed some commas that were syntactically placed as parenthetical commas despite the contained information not actually being parenthetical.