### PR TITLE
Reactively update title and buttons

### DIFF
--- a/src/js/components/shepherd-button.svelte
+++ b/src/js/components/shepherd-button.svelte
@@ -3,8 +3,12 @@
   import { isFunction } from '../utils/type-check';
 
   export let config, step;
+  let action, classes, secondary, text, label;
 
-  $: ({ action, classes, secondary, text, label } = config);
+  $: {
+    action = config.action ? config.action.bind(step.tour) : null;
+    ({ classes, secondary, text, label } = config);
+  }
 
   let disabled = false;
 
@@ -57,7 +61,7 @@
   aria-label="{label ? label : null}"
   class="{`${(classes || '')} shepherd-button ${(secondary ? 'shepherd-button-secondary' : '')}`}"
   disabled={disabled}
-  on:click={action ? action.bind(step.tour) : null}
+  on:click={action}
   tabindex="0"
 >
     {text}

--- a/src/js/components/shepherd-button.svelte
+++ b/src/js/components/shepherd-button.svelte
@@ -3,7 +3,13 @@
   import { isFunction } from '../utils/type-check';
 
   export let config, step;
-  const { action, classes, secondary, text, label } = config;
+
+  $: action = config.action;
+  $: classes = config.classes;
+  $: secondary = config.secondary;
+  $: text = config.text;
+  $: label = config.label;
+
   let disabled = false;
 
   afterUpdate(() => {
@@ -13,6 +19,8 @@
       if (isFunction(disabled)) {
         disabled = disabled.call(step);
       }
+    } else {
+      disabled = false;
     }
   });
 </script>

--- a/src/js/components/shepherd-button.svelte
+++ b/src/js/components/shepherd-button.svelte
@@ -1,28 +1,25 @@
 <script>
-  import { afterUpdate } from 'svelte';
   import { isFunction } from '../utils/type-check';
 
   export let config, step;
-  let action, classes, secondary, text, label;
+  let action, classes, secondary, text, label, disabled;
 
   $: {
     action = config.action ? config.action.bind(step.tour) : null;
-    ({ classes, secondary, text, label } = config);
+    classes = config.classes;
+    secondary = config.secondary;
+    text = config.text;
+    label = config.label;
+    disabled = config.disabled ? getDisabled(config.disabled) : false;
   }
 
-  let disabled = false;
-
-  afterUpdate(() => {
-    if (config.disabled) {
-      disabled = config.disabled;
-
+  function getDisabled(disabled) {
       if (isFunction(disabled)) {
-        disabled = disabled.call(step);
+          return disabled = disabled.call(step);
       }
-    } else {
-      disabled = false;
-    }
-  });
+      return disabled
+  }
+
 </script>
 
 <style global>

--- a/src/js/components/shepherd-button.svelte
+++ b/src/js/components/shepherd-button.svelte
@@ -4,11 +4,7 @@
 
   export let config, step;
 
-  $: action = config.action;
-  $: classes = config.classes;
-  $: secondary = config.secondary;
-  $: text = config.text;
-  $: label = config.label;
+  $: ({ action, classes, secondary, text, label } = config);
 
   let disabled = false;
 

--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -10,9 +10,14 @@
 
   export let classes, classPrefix, element, descriptionId, firstFocusableElement,
     focusableElements, labelId, lastFocusableElement, step;
-  const dataStepId = { [`data-${classPrefix}shepherd-step-id`]: step.id };
-  const hasCancelIcon = step.options && step.options.cancelIcon && step.options.cancelIcon.enabled;
-  const hasTitle = step.options && step.options.title;
+
+  let dataStepId, hasCancelIcon, hasTitle;
+
+  $: {
+    dataStepId = { [`data-${classPrefix}shepherd-step-id`]: step.id };
+    hasCancelIcon = step.options && step.options.cancelIcon && step.options.cancelIcon.enabled;
+    hasTitle = step.options && step.options.title;
+  }
 
   export const getElement = () => element;
 

--- a/src/js/components/shepherd-footer.svelte
+++ b/src/js/components/shepherd-footer.svelte
@@ -2,7 +2,8 @@
   import ShepherdButton from './shepherd-button.svelte';
 
   export let step;
-  const { buttons } = step.options;
+
+  $: buttons = step.options.buttons;
 </script>
 
 <style global>

--- a/src/js/components/shepherd-header.svelte
+++ b/src/js/components/shepherd-header.svelte
@@ -3,8 +3,12 @@
   import ShepherdTitle from './shepherd-title.svelte';
 
   export let labelId, step;
+  let title, cancelIcon;
 
-  $: ({title, cancelIcon} = step.options);
+  $: {
+      title = step.options.title;
+      cancelIcon = step.options.cancelIcon;
+  }
 </script>
 
 <style global>

--- a/src/js/components/shepherd-header.svelte
+++ b/src/js/components/shepherd-header.svelte
@@ -4,8 +4,7 @@
 
   export let labelId, step;
 
-  $: title = step.options.title;
-  $: cancelIcon = step.options.cancelIcon;
+  $: ({title, cancelIcon} = step.options);
 </script>
 
 <style global>

--- a/src/js/components/shepherd-header.svelte
+++ b/src/js/components/shepherd-header.svelte
@@ -3,7 +3,9 @@
   import ShepherdTitle from './shepherd-title.svelte';
 
   export let labelId, step;
-  const { cancelIcon, title } = step.options;
+
+  $: title = step.options.title;
+  $: cancelIcon = step.options.cancelIcon;
 </script>
 
 <style global>

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -256,7 +256,7 @@ export class Step extends Evented {
 
     if (isFunction(this.options.scrollToHandler)) {
       this.options.scrollToHandler(element);
-    } else if (isElement(element)) {
+    } else if (isElement(element) && typeof element.scrollIntoView === 'function') {
       element.scrollIntoView(scrollToOptions);
     }
   }

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -202,48 +202,74 @@ describe('Tour | Step', () => {
   });
 
   describe('updateStepOptions', () => {
-    it('should update passed in properties', () => {
-      const step = new Step(tour, {
+    let step;
+
+    beforeEach(() => {
+      step = new Step(tour, {
         id: 'test-id',
         text: 'Lorem Ipsum',
         title: 'Test',
-        cancelIcon: true
+        scrollTo: false,
+        buttons: [
+          { text: 'button one', disabled: false, classes: 'button1' },
+          { text: 'button two', disabled: true, classes: 'button2' }
+        ]
       });
+      step.show();
+    });
 
+    afterEach(() => {
+      step.destroy();
+    });
+
+    it('should update passed in properties', (done) => {
       step.updateStepOptions({ text: 'updated', title: 'New title' });
+
       expect(step.options.text).toBe('updated');
       expect(step.options.title).toBe('New title');
+
+      requestAnimationFrame(() => {
+        expect(document.querySelector('.shepherd-text').textContent).toBe('updated');
+        expect(document.querySelector('.shepherd-title').textContent).toBe('New title');
+        done();
+      });
     });
 
-    it('should not affect other properties', () => {
-      const step = new Step(tour, {
-        id: 'test-id',
-        text: 'Lorem Ipsum',
-        title: 'Test',
-        cancelIcon: true
-      });
-
+    it('should not affect other properties', (done) => {
       step.updateStepOptions({ text: 'updated', title: 'New title' });
       expect(step.options.id).toEqual('test-id');
-      expect(step.options.cancelIcon).toBeTruthy();
+      expect(step.options.buttons).toEqual([
+        { text: 'button one', disabled: false, classes: 'button1' },
+        { text: 'button two', disabled: true, classes: 'button2' }
+      ]);
+
+      requestAnimationFrame(() => {
+        expect(document.querySelector('.button1').textContent).toBe('button one');
+        expect(document.querySelector('.button2').textContent).toBe('button two');
+        done();
+      });
     });
 
-    it('should update tooltip content', () => {
-      const step = new Step(tour, {
-        id: 'test-id',
-        text: 'Lorem Ipsum',
-        title: 'Test',
-        cancelIcon: true
+    it('should update buttons', (done) => {
+      step.show();
+      const buttons = [
+        { text: 'button one updated', disabled: true, classes: 'button1' },
+        { text: 'button two updated', disabled: false, classes: 'button2' }
+      ];
+
+      step.updateStepOptions({ buttons });
+      expect(step.options.buttons).toEqual(buttons);
+
+      requestAnimationFrame(() => {
+        const buttonOne = document.querySelector('.button1');
+        expect(buttonOne.textContent).toBe('button one updated');
+        expect(buttonOne.disabled).toBe(true);
+
+        const buttonTwo = document.querySelector('.button2');
+        expect(buttonTwo.textContent).toBe('button two updated');
+        expect(buttonTwo.disabled).toBe(false);
+        done();
       });
-
-      let called = false;
-
-      step._createTooltipContent();
-      step.shepherdElementComponent.$set = () => called = true;
-
-      step.updateStepOptions({ text: 'updated', title: 'New title' });
-
-      expect(called).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
This change makes it so changes made with `updateStepOptions` actually update the template.  
The `$:` label syntax makes the statement reactive, and executes it on each update of the inputs 