### PR TITLE
Fix dynamic shepherd classes interfering with tether classes

### DIFF
--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -165,7 +165,9 @@
   aria-describedby={!isUndefined(step.options.text) ? descriptionId : null}
   aria-labelledby={step.options.title ? labelId : null}
   bind:this={element}
-  class="{`${classes} shepherd-element ${hasCancelIcon ? 'shepherd-has-cancel-icon' : ''} ${hasTitle ? 'shepherd-has-title' : ''}`}"
+  class:shepherd-has-cancel-icon="{hasCancelIcon}"
+  class:shepherd-has-title="{hasTitle}"
+  class="{`${classes} shepherd-element`}"
   {...dataStepId}
   on:keydown={handleKeyDown}
   role="dialog"

--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -42,7 +42,7 @@
 
   function removeClasses(classes) {
     if (isString(classes)) {
-      const oldClasses = classes.split(' ');
+      const oldClasses = getClassesArray(classes);
       if (oldClasses.length) {
         element.classList.remove(...oldClasses);
       }
@@ -51,11 +51,15 @@
 
   function addClasses(classes) {
     if(isString(classes)) {
-      const newClasses = classes.split(' ').filter(className => !!className.length);
+      const newClasses = getClassesArray(classes);
       if (newClasses.length) {
         element.classList.add(...newClasses);
       }
     }
+  }
+
+  function getClassesArray(classes) {
+     return classes.split(' ').filter(className => !!className.length);
   }
 
   /**

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -223,7 +223,6 @@ export class Step extends Evented {
    * @private
    */
   _createTooltipContent() {
-    const classes = this.options.classes || '';
     const descriptionId = `${this.id}-description`;
     const labelId = `${this.id}-label`;
 
@@ -232,7 +231,6 @@ export class Step extends Evented {
       props:
         {
           classPrefix: this.classPrefix,
-          classes,
           descriptionId,
           labelId,
           step: this,

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -303,7 +303,6 @@ describe('Tour | Step', () => {
 
       requestAnimationFrame(() => {
         const element = document.querySelector('.shepherd-element');
-        console.log(element.classList);
         expect(element.classList.contains('shepherd-element-attached-bottom')).toBeTruthy();
         expect(element.classList.contains('shepherd-element-attached-center')).toBeTruthy();
         expect(element.classList.contains('shepherd-target-attached-top')).toBeTruthy();

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -207,7 +207,9 @@ describe('Tour | Step', () => {
     beforeEach(() => {
       step = new Step(tour, {
         id: 'test-id',
+        attachTo: { element: 'body', on: 'top' },
         text: 'Lorem Ipsum',
+        classes: 'classes-test',
         title: 'Test',
         scrollTo: false,
         buttons: [
@@ -251,7 +253,6 @@ describe('Tour | Step', () => {
     });
 
     it('should update buttons', (done) => {
-      step.show();
       const buttons = [
         { text: 'button one updated', disabled: true, classes: 'button1' },
         { text: 'button two updated', disabled: false, classes: 'button2' }
@@ -268,6 +269,45 @@ describe('Tour | Step', () => {
         const buttonTwo = document.querySelector('.button2');
         expect(buttonTwo.textContent).toBe('button two updated');
         expect(buttonTwo.disabled).toBe(false);
+        done();
+      });
+    });
+
+    it('removing title should remove class', (done) => {
+      step.updateStepOptions({ title: '' });
+      expect(step.options.title).toEqual('');
+
+      requestAnimationFrame(() => {
+        const element = document.querySelector('.shepherd-element');
+        expect(element.classList.contains('shepherd-has-title')).toBeFalsy();
+        done();
+      });
+    });
+
+    it('updating classes should update element classes', (done) => {
+      step.updateStepOptions({ classes: 'test-1 test-2' });
+      expect(step.options.classes).toEqual('test-1 test-2');
+
+      requestAnimationFrame(() => {
+        const element = document.querySelector('.shepherd-element');
+        expect(element.classList.contains('test-1')).toBeTruthy();
+        expect(element.classList.contains('test-2')).toBeTruthy();
+        expect(element.classList.contains('classes-test')).toBeFalsy();
+        done();
+      });
+    });
+
+    it('updating classes should not overwrite tether classes', (done) => {
+      step.updateStepOptions({ classes: 'test-1 test-2' });
+      expect(step.options.classes).toEqual('test-1 test-2');
+
+      requestAnimationFrame(() => {
+        const element = document.querySelector('.shepherd-element');
+        console.log(element.classList);
+        expect(element.classList.contains('shepherd-element-attached-bottom')).toBeTruthy();
+        expect(element.classList.contains('shepherd-element-attached-center')).toBeTruthy();
+        expect(element.classList.contains('shepherd-target-attached-top')).toBeTruthy();
+        expect(element.classList.contains('shepherd-target-attached-center')).toBeTruthy();
         done();
       });
     });


### PR DESCRIPTION
#655 Allowed the title to be changed reactively, but this caused an issue with the dynamically updated classes on the shepherd-element.  
The issue was that they overrode the classes tether is putting for position and the element disappeared altogether.  
By using the svelte class directive this will no longer be an issue as only the needed classes will be updated, not the whole class list.
