### PR TITLE
Added Border Radius Feature

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -182,6 +182,7 @@ the step will execute. For example:
   - `enabled` Should a cancel “✕” be shown in the header of the step?
   - `label` The label to add for `aria-label`
 - `classes`: A string of extra classes to add to the step's content element.
+- `borderRadius`: An amount of border radius to add around the modal overlay opening
 - `buttons`: An array of buttons to add to the step. These will be rendered in a footer below the main body text. Each button in the array is an object of the format:
   - `text`: The HTML text of the button
   - `classes`: Extra classes to apply to the `<a>`

--- a/src/js/components/shepherd-modal.svelte
+++ b/src/js/components/shepherd-modal.svelte
@@ -12,6 +12,7 @@
 
   export function closeModalOpening() {
     openingProperties = {
+      borderRadius: 0,
       height: 0,
       x: 0,
       y: 0,
@@ -34,14 +35,16 @@
    * @param {HTMLElement} targetElement The element the opening will expose
    * @param {HTMLElement} scrollParent The scrollable parent of the target element
    * @param {Number} modalOverlayOpeningPadding An amount of padding to add around the modal overlay opening
+   * @param {Number} borderRadius An amount of border radius to add around the modal overlay opening
    */
-  export function positionModalOpening(targetElement, scrollParent, modalOverlayOpeningPadding = 0) {
+  export function positionModalOpening(targetElement, scrollParent, modalOverlayOpeningPadding = 0, borderRadius = 0) {
     if (targetElement.getBoundingClientRect) {
       const { y, height } = _getVisibleHeight(targetElement, scrollParent);
       const { x, width, left } = targetElement.getBoundingClientRect();
 
       // getBoundingClientRect is not consistent. Some browsers use x and y, while others use left and top
       openingProperties = {
+        borderRadius: borderRadius,
         x: (x || left) - modalOverlayOpeningPadding,
         y: y - modalOverlayOpeningPadding,
         width: (width + (modalOverlayOpeningPadding * 2)),
@@ -113,7 +116,7 @@
    * @private
    */
   function _styleForStep(step) {
-    const { modalOverlayOpeningPadding } = step.options;
+    const { modalOverlayOpeningPadding, borderRadius } = step.options;
 
     if (step.target) {
       const scrollParent = _getScrollParent(step.target);
@@ -121,7 +124,7 @@
       // Setup recursive function to call requestAnimationFrame to update the modal opening position
       const rafLoop = () => {
         rafId = undefined;
-        positionModalOpening(step.target, scrollParent, modalOverlayOpeningPadding);
+        positionModalOpening(step.target, scrollParent, step.options.modalOverlayOpeningPadding, step.options.borderRadius);
         rafId = requestAnimationFrame(rafLoop);
       };
 
@@ -219,6 +222,5 @@
   on:touchmove={_preventModalOverlayTouch}
 >
   <path
-    d="{`M ${openingProperties.x} ${openingProperties.y} H ${openingProperties.width + openingProperties.x} V ${openingProperties.height + openingProperties.y} H ${openingProperties.x} L ${openingProperties.x} 0 Z M 0 0 H ${window.innerWidth} V ${window.innerHeight} H 0 L 0 0 Z`}">
-  </path>
+    d="{`M ${openingProperties.x} ${openingProperties.y} H ${openingProperties.width + openingProperties.x - openingProperties.borderRadius} A ${openingProperties.borderRadius} ${openingProperties.borderRadius} 0 0 1 ${openingProperties.borderRadius} ${openingProperties.borderRadius} V ${openingProperties.height + openingProperties.y - openingProperties.borderRadius} A ${openingProperties.borderRadius} ${openingProperties.borderRadius} 0 0 1 -${openingProperties.borderRadius} ${openingProperties.borderRadius} H ${openingProperties.x + openingProperties.borderRadius} A ${openingProperties.borderRadius} ${openingProperties.borderRadius} 0 0 1 -${openingProperties.borderRadius} -${openingProperties.borderRadius} V ${openingProperties.y + openingProperties.borderRadius} A ${openingProperties.borderRadius} ${openingProperties.borderRadius} 0 0 1 ${openingProperties.borderRadius} -${openingProperties.borderRadius} Z M 0 0 H ${window.innerWidth} V ${window.innerHeight} H 0 L 0 0 Z`}">
 </svg>

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -46,6 +46,7 @@ export class Step extends Evented {
    * ```
    * `event` doesn’t have to be an event inside the tour, it can be any event fired on any element on the page.
    * You can also always manually advance the Tour by calling `myTour.next()`.
+   * @param {Number} options.borderRadius Extra border radius to be applied for the overlay element
    * @param {function} options.beforeShowPromise A function that returns a promise.
    * When the promise resolves, the rest of the `show` code for the step will execute.
    * @param {Object[]} options.buttons An array of buttons to add to the step. These will be rendered in a

--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -98,6 +98,11 @@ declare namespace Step {
     beforeShowPromise?: (() => Promise<any>);
 
     /**
+     * An amount of border radius to add around the modal overlay opening
+     */
+    borderRadius?: number;
+
+    /**
      * An array of buttons to add to the step. These will be rendered in a
      * footer below the main body text.
      */

--- a/test/unit/components/shepherd-modal.spec.js
+++ b/test/unit/components/shepherd-modal.spec.js
@@ -28,13 +28,13 @@ describe('components/ShepherdModal', () => {
 
       let modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 20 20 H 520 V 270 H 20 L 20 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M 20 20 H 520 A 0 0 0 0 1 0 0 V 270 A 0 0 0 0 1 -0 0 H 20 A 0 0 0 0 1 -0 -0 V 20 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       await modalComponent.closeModalOpening();
 
       modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 0 0 H 0 V 0 H 0 L 0 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M 0 0 H 0 A 0 0 0 0 1 0 0 V 0 A 0 0 0 0 1 -0 0 H 0 A 0 0 0 0 1 -0 -0 V 0 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       modalComponent.$destroy();
     });
@@ -51,13 +51,13 @@ describe('components/ShepherdModal', () => {
       });
 
       let modalPath = modalComponent.getElement().querySelector('path');
-      expect(modalPath).toHaveAttribute('d', 'M 0 0 H 0 V 0 H 0 L 0 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+      expect(modalPath).toHaveAttribute('d', 'M 0 0 H 0 A 0 0 0 0 1 0 0 V 0 A 0 0 0 0 1 -0 0 H 0 A 0 0 0 0 1 -0 -0 V 0 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       await modalComponent.closeModalOpening();
 
       modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 0 0 H 0 V 0 H 0 L 0 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M 0 0 H 0 A 0 0 0 0 1 0 0 V 0 A 0 0 0 0 1 -0 0 H 0 A 0 0 0 0 1 -0 -0 V 0 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       await modalComponent.positionModalOpening({
         getBoundingClientRect() {
@@ -72,7 +72,43 @@ describe('components/ShepherdModal', () => {
 
       modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 20 20 H 520 V 270 H 20 L 20 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M 20 20 H 520 A 0 0 0 0 1 0 0 V 270 A 0 0 0 0 1 -0 0 H 20 A 0 0 0 0 1 -0 -0 V 20 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+
+      modalComponent.$destroy();
+    });
+    
+    it('sets the correct attributes when positioning modal opening with border radius', async() => {
+      const modalComponent = new ShepherdModal({
+        target: document.body,
+        props:
+          {
+            classPrefix
+          }
+      });
+
+      let modalPath = modalComponent.getElement().querySelector('path');
+      expect(modalPath).toHaveAttribute('d', 'M 0 0 H 0 A 0 0 0 0 1 0 0 V 0 A 0 0 0 0 1 -0 0 H 0 A 0 0 0 0 1 -0 -0 V 0 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+
+      await modalComponent.closeModalOpening();
+
+      modalPath = modalComponent.getElement().querySelector('path');
+      expect(modalPath)
+        .toHaveAttribute('d', 'M 0 0 H 0 A 0 0 0 0 1 0 0 V 0 A 0 0 0 0 1 -0 0 H 0 A 0 0 0 0 1 -0 -0 V 0 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+
+      await modalComponent.positionModalOpening({
+        getBoundingClientRect() {
+          return {
+            height: 250,
+            x: 20,
+            y: 20,
+            width: 500
+          };
+        }
+      }, null, 0, 10);
+
+      modalPath = modalComponent.getElement().querySelector('path');
+      expect(modalPath)
+        .toHaveAttribute('d', 'M 20 20 H 510 A 10 10 0 0 1 10 10 V 260 A 10 10 0 0 1 -10 10 H 30 A 10 10 0 0 1 -10 -10 V 30 A 10 10 0 0 1 10 -10 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       modalComponent.$destroy();
     });
@@ -87,7 +123,7 @@ describe('components/ShepherdModal', () => {
       });
 
       let modalPath = modalComponent.getElement().querySelector('path');
-      expect(modalPath).toHaveAttribute('d', 'M 0 0 H 0 V 0 H 0 L 0 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+      expect(modalPath).toHaveAttribute('d', 'M 0 0 H 0 A 0 0 0 0 1 0 0 V 0 A 0 0 0 0 1 -0 0 H 0 A 0 0 0 0 1 -0 -0 V 0 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       await modalComponent.positionModalOpening({
         getBoundingClientRect() {
@@ -102,7 +138,7 @@ describe('components/ShepherdModal', () => {
 
       modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 10 10 H 530 V 280 H 10 L 10 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M 10 10 H 530 A 0 0 0 0 1 0 0 V 280 A 0 0 0 0 1 -0 0 H 10 A 0 0 0 0 1 -0 -0 V 10 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       modalComponent.$destroy();
     });
@@ -136,7 +172,7 @@ describe('components/ShepherdModal', () => {
       }, 0);
 
       const modalPath = modalComponent.getElement().querySelector('path');
-      expect(modalPath).toHaveAttribute('d', 'M 10 100 H 510 V 350 H 10 L 10 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+      expect(modalPath).toHaveAttribute('d', 'M 10 100 H 510 A 0 0 0 0 1 0 0 V 350 A 0 0 0 0 1 -0 0 H 10 A 0 0 0 0 1 -0 -0 V 100 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       modalComponent.$destroy();
     });
@@ -170,7 +206,7 @@ describe('components/ShepherdModal', () => {
       }, 0);
 
       const modalPath = modalComponent.getElement().querySelector('path');
-      expect(modalPath).toHaveAttribute('d', 'M 10 100 H 510 V 350 H 10 L 10 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+      expect(modalPath).toHaveAttribute('d', 'M 10 100 H 510 A 0 0 0 0 1 0 0 V 350 A 0 0 0 0 1 -0 0 H 10 A 0 0 0 0 1 -0 -0 V 100 A 0 0 0 0 1 0 -0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
 
       modalComponent.$destroy();
     });


### PR DESCRIPTION
The Shepherd Library has helped the product we are developing in a whole new way. having said that we faced some issues on highlighting elements during the step navigations. The issue was we were not able to give a rounded borders to the highlighted elements and no convincing methods were found in the docs or issues whatsoever.

The PR contains the ability to pass `borderRadius` as a parameter in options of the step to add rounded corners with customized radius. Please go ahead and review the PR. Would be happy to solve any doubts or changes if required.

Things completed for this feature includes,
* Added `borderRadius` as an optional parameter in `step.d.ts` / `step.js`.
* Added the entry in wiki for `02-usage.md`.
* Modified SVG building to support `borderRadius` and necessary code changes to accept `borderRadius` just like `modalOverlayOpeningPadding` feature in `shepherd-model.svelte`.
* Modified Unit Tests to support borderRadius and added a new test for the same feature.

Thanks with regards,
Praveen Thirumurugan.