### PR TITLE
🐛 Fix initial scroll to top before scrolling to target

### DIFF
--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -128,8 +128,6 @@
   }
 
   .shepherd-element[data-popper-reference-hidden]:not(.shepherd-centered) {
-    visibility: hidden;
-    pointer-events: none;
     opacity: 0;
   }
 

--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -127,6 +127,12 @@
     opacity: 1;
   }
 
+  .shepherd-element[data-popper-reference-hidden]:not(.shepherd-centered) {
+    visibility: hidden;
+    pointer-events: none;
+    opacity: 0;
+  }
+
   .shepherd-element, .shepherd-element *,
   .shepherd-element *:after,
   .shepherd-element *:before {

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -7,7 +7,6 @@ import ShepherdElement from './components/shepherd-element.svelte';
 
 // Polyfills
 import smoothscroll from 'smoothscroll-polyfill';
-
 smoothscroll.polyfill();
 
 /**
@@ -329,7 +328,6 @@ export class Step extends Evented {
     if (this.options.advanceOn) {
       bindAdvance(this);
     }
-
     setupTooltip(this);
   }
 
@@ -345,21 +343,21 @@ export class Step extends Evented {
 
     this.tour.modal.setupForStep(this);
     this._styleTargetElementForStep(this);
-
     this.el.hidden = false;
 
-    this.tooltip.update();
-
-    const content = this.shepherdElementComponent.getElement();
-    const target = this.target || document.body;
-    target.classList.add(`${this.classPrefix}shepherd-enabled`, `${this.classPrefix}shepherd-target`);
-    content.classList.add('shepherd-enabled');
-
+    // start scrolling to target before showing the step
     if (this.options.scrollTo) {
       setTimeout(() => {
         this._scrollTo(this.options.scrollTo);
       });
     }
+
+    this.el.hidden = false;
+
+    const content = this.shepherdElementComponent.getElement();
+    const target = this.target || document.body;
+    target.classList.add(`${this.classPrefix}shepherd-enabled`, `${this.classPrefix}shepherd-target`);
+    content.classList.add('shepherd-enabled');
 
     this.trigger('show');
     this.el.focus();

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -360,7 +360,6 @@ export class Step extends Evented {
     content.classList.add('shepherd-enabled');
 
     this.trigger('show');
-    this.el.focus();
   }
 
   /**

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -117,8 +117,6 @@ export function getPopperOptions(attachToOptions, step) {
 
       delete step.options.popperOptions.modifiers;
     }
-    console.log(popperOptions);
-    console.log(step.options);
 
     popperOptions = Object.assign(popperOptions, step.options.popperOptions);
   }

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -117,8 +117,10 @@ export function getPopperOptions(attachToOptions, step) {
 
       delete step.options.popperOptions.modifiers;
     }
+    console.log(popperOptions);
+    console.log(step.options);
 
-    popperOptions = Object.assign(...popperOptions, ...step.options.popperOptions);
+    popperOptions = Object.assign(popperOptions, step.options.popperOptions);
   }
 
   return { element: step.el, popperOptions, target };

--- a/src/js/utils/popper-options.js
+++ b/src/js/utils/popper-options.js
@@ -8,6 +8,7 @@ function _getCenteredStylePopperModifier() {
             return;
           }
           const style = {
+            position: 'fixed',
             left: '50%',
             top: '50%',
             transform: 'translate(-50%, -50%)'
@@ -59,11 +60,14 @@ export function makeCenteredPopper(step) {
   return popperOptions;
 }
 
-function _makeCommonPopperOptions() {
+function _makeCommonPopperOptions(step) {
   const popperOptions = {
     placement: 'top',
     strategy: 'fixed',
-    modifiers: []
+    modifiers: [],
+    onFirstUpdate() {
+      step.el.focus();
+    }
   };
 
   return popperOptions;

--- a/src/js/utils/popper-options.js
+++ b/src/js/utils/popper-options.js
@@ -47,11 +47,10 @@ function _getCenteredStylePopperModifier() {
  */
 export function makeCenteredPopper(step) {
   const centeredStylePopperModifier = _getCenteredStylePopperModifier(step);
+  const content = step.shepherdElementComponent.getElement();
   let popperOptions = _makeCommonPopperOptions(step);
 
-  popperOptions.placement = 'top';
-  popperOptions.strategy = 'absolute';
-
+  content.classList.add('shepherd-centered');
   popperOptions = {
     ...popperOptions,
     modifiers: Array.from(new Set([...popperOptions.modifiers, ...centeredStylePopperModifier]))
@@ -62,6 +61,7 @@ export function makeCenteredPopper(step) {
 
 function _makeCommonPopperOptions() {
   const popperOptions = {
+    placement: 'top',
     strategy: 'fixed',
     modifiers: []
   };

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -13,10 +13,10 @@ describe('General Utils', function() {
     });
   });
 
-  describe.only('getPopperOptions', function() {
+  describe('getPopperOptions', function() {
     it('modifiers can be overridden', function() {
       const step = new Step({}, {
-        attachTo: { element: '.scroll-test', on: 'center' },
+        attachTo: { element: '.scroll-test', on: 'right' },
         popperOptions: {
           modifiers: [
             {
@@ -29,7 +29,7 @@ describe('General Utils', function() {
         }
       });
 
-      const { popperOptions } = getPopperOptions(parseAttachTo(step), step);
+      const { popperOptions } = getPopperOptions(step.options.attachTo, step);
       expect(popperOptions.modifiers[0].options.altAxis).toBe(false);
     });
 
@@ -43,7 +43,7 @@ describe('General Utils', function() {
         }
       });
 
-      const { popperOptions } = getPopperOptions(parseAttachTo(step), step);
+      const { popperOptions } = getPopperOptions(step.options.attachTo, step);
       expect(popperOptions.strategy).toBe('absolute');
     });
   });


### PR DESCRIPTION
This fixes the issue with the document scrolling to top before each step is shown. Also, removes extra renders via the forced update in `_step()` method.