### PR TITLE
Single argument on classList.add for IE11 compatibility

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -356,7 +356,8 @@ export class Step extends Evented {
 
     const content = this.shepherdElementComponent.getElement();
     const target = this.target || document.body;
-    target.classList.add(`${this.classPrefix}shepherd-enabled`, `${this.classPrefix}shepherd-target`);
+    target.classList.add(`${this.classPrefix}shepherd-enabled`);
+    target.classList.add(`${this.classPrefix}shepherd-target`);
     content.classList.add('shepherd-enabled');
 
     this.trigger('show');


### PR DESCRIPTION
According to MDN web docs (https://developer.mozilla.org/en-US/docs/Web/API/Element/classList and https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/add) Internet Explorer doesn't support multiple arguments for classList.add().
This adds the two classes is separate statements to keep compatibility with IE11.