### PR TITLE
Feature/modal overlay border radius

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -213,6 +213,7 @@ You can also always manually advance the Tour by calling `myTour.next()`.
 - `highlightClass`: An extra class to apply to the `attachTo` element when it is highlighted (that is, when its step is active). You can then target that selector in your CSS.
 - `id`: The string to use as the `id` for the step. If an id is not passed one will be generated.
 - `modalOverlayOpeningPadding`: An amount of padding to add around the modal overlay opening
+- `modalOverlayOpeningRadius`: An amount of border radius to add around the modal overlay opening
 - `popperOptions`: Extra options to pass to [Popper](https://popper.js.org/docs/v2/constructors/#options)
 - `showOn`: A function that, when it returns true, will show the step. If it returns false, the step will be skipped.
 - `scrollTo`: Should the element be scrolled to when this step is shown?

--- a/src/js/components/shepherd-modal.svelte
+++ b/src/js/components/shepherd-modal.svelte
@@ -12,6 +12,7 @@
 
   export function closeModalOpening() {
     openingProperties = {
+      borderRadius: 0,
       height: 0,
       x: 0,
       y: 0,
@@ -34,14 +35,16 @@
    * @param {HTMLElement} targetElement The element the opening will expose
    * @param {HTMLElement} scrollParent The scrollable parent of the target element
    * @param {Number} modalOverlayOpeningPadding An amount of padding to add around the modal overlay opening
+   * @param {Number} modalOverlayOpeningRadius An amount of border radius to add around the modal overlay opening
    */
-  export function positionModalOpening(targetElement, scrollParent, modalOverlayOpeningPadding = 0) {
+  export function positionModalOpening(targetElement, scrollParent, modalOverlayOpeningPadding = 0, modalOverlayOpeningRadius = 0) {
     if (targetElement.getBoundingClientRect) {
       const { y, height } = _getVisibleHeight(targetElement, scrollParent);
       const { x, width, left } = targetElement.getBoundingClientRect();
 
       // getBoundingClientRect is not consistent. Some browsers use x and y, while others use left and top
       openingProperties = {
+        borderRadius: modalOverlayOpeningRadius,
         x: (x || left) - modalOverlayOpeningPadding,
         y: y - modalOverlayOpeningPadding,
         width: (width + (modalOverlayOpeningPadding * 2)),
@@ -113,7 +116,7 @@
    * @private
    */
   function _styleForStep(step) {
-    const { modalOverlayOpeningPadding } = step.options;
+    const { modalOverlayOpeningPadding, modalOverlayOpeningRadius } = step.options;
 
     if (step.target) {
       const scrollParent = _getScrollParent(step.target);
@@ -121,7 +124,7 @@
       // Setup recursive function to call requestAnimationFrame to update the modal opening position
       const rafLoop = () => {
         rafId = undefined;
-        positionModalOpening(step.target, scrollParent, modalOverlayOpeningPadding);
+        positionModalOpening(step.target, scrollParent, modalOverlayOpeningPadding, modalOverlayOpeningRadius);
         rafId = requestAnimationFrame(rafLoop);
       };
 
@@ -189,7 +192,6 @@
   .shepherd-modal-overlay-container {
     -ms-filter: progid:dximagetransform.microsoft.gradient.alpha(Opacity=50);
     filter: alpha(opacity=50);
-    fill-rule: evenodd;
     height: 0;
     left: 0;
     opacity: 0;
@@ -219,6 +221,6 @@
   on:touchmove={_preventModalOverlayTouch}
 >
   <path
-    d="{`M ${openingProperties.x} ${openingProperties.y} H ${openingProperties.width + openingProperties.x} V ${openingProperties.height + openingProperties.y} H ${openingProperties.x} L ${openingProperties.x} 0 Z M 0 0 H ${window.innerWidth} V ${window.innerHeight} H 0 L 0 0 Z`}">
+    d="{`M${window.innerWidth},${window.innerHeight}H0V0H${window.innerWidth}V${window.innerHeight}ZM${openingProperties.x + openingProperties.borderRadius},${openingProperties.y}a${openingProperties.borderRadius},${openingProperties.borderRadius},0,0,0-${openingProperties.borderRadius},${openingProperties.borderRadius}V${openingProperties.height + openingProperties.y - openingProperties.borderRadius}a${openingProperties.borderRadius},${openingProperties.borderRadius},0,0,0,${openingProperties.borderRadius},${openingProperties.borderRadius}H${openingProperties.width + openingProperties.x - openingProperties.borderRadius}a${openingProperties.borderRadius},${openingProperties.borderRadius},0,0,0,${openingProperties.borderRadius}-${openingProperties.borderRadius}V${openingProperties.y + openingProperties.borderRadius}a${openingProperties.borderRadius},${openingProperties.borderRadius},0,0,0-${openingProperties.borderRadius}-${openingProperties.borderRadius}Z`}">
   </path>
 </svg>

--- a/src/js/components/shepherd-modal.svelte
+++ b/src/js/components/shepherd-modal.svelte
@@ -1,10 +1,14 @@
 <script>
   import { uuid } from '../utils/general.js';
+  import { makeOverlayPath } from '../utils/overlay-path.js';
 
   export let element, openingProperties;
   const guid = uuid();
   let modalIsVisible = false;
   let rafId = undefined;
+  let pathDefinition;
+
+  $: pathDefinition = makeOverlayPath(openingProperties);
 
   closeModalOpening();
 
@@ -12,11 +16,11 @@
 
   export function closeModalOpening() {
     openingProperties = {
-      borderRadius: 0,
+      width: 0,
       height: 0,
       x: 0,
       y: 0,
-      width: 0
+      r: 0
     };
   }
 
@@ -44,11 +48,11 @@
 
       // getBoundingClientRect is not consistent. Some browsers use x and y, while others use left and top
       openingProperties = {
-        borderRadius: modalOverlayOpeningRadius,
+        width: (width + (modalOverlayOpeningPadding * 2)),
+        height: (height + (modalOverlayOpeningPadding * 2)),
         x: (x || left) - modalOverlayOpeningPadding,
         y: y - modalOverlayOpeningPadding,
-        width: (width + (modalOverlayOpeningPadding * 2)),
-        height: (height + (modalOverlayOpeningPadding * 2))
+        r: modalOverlayOpeningRadius
       };
     }
   }
@@ -220,7 +224,5 @@
   class="{`${(modalIsVisible ? 'shepherd-modal-is-visible' : '')} shepherd-modal-overlay-container`}"
   on:touchmove={_preventModalOverlayTouch}
 >
-  <path
-    d="{`M${window.innerWidth},${window.innerHeight}H0V0H${window.innerWidth}V${window.innerHeight}ZM${openingProperties.x + openingProperties.borderRadius},${openingProperties.y}a${openingProperties.borderRadius},${openingProperties.borderRadius},0,0,0-${openingProperties.borderRadius},${openingProperties.borderRadius}V${openingProperties.height + openingProperties.y - openingProperties.borderRadius}a${openingProperties.borderRadius},${openingProperties.borderRadius},0,0,0,${openingProperties.borderRadius},${openingProperties.borderRadius}H${openingProperties.width + openingProperties.x - openingProperties.borderRadius}a${openingProperties.borderRadius},${openingProperties.borderRadius},0,0,0,${openingProperties.borderRadius}-${openingProperties.borderRadius}V${openingProperties.y + openingProperties.borderRadius}a${openingProperties.borderRadius},${openingProperties.borderRadius},0,0,0-${openingProperties.borderRadius}-${openingProperties.borderRadius}Z`}">
-  </path>
+  <path d="{pathDefinition}"></path>
 </svg>

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -98,6 +98,7 @@ export class Step extends Evented {
    * }
    * ```
    * @param {Number} options.modalOverlayOpeningPadding An amount of padding to add around the modal overlay opening
+   * @param {Number} options.modalOverlayOpeningRadius An amount of border radius to add around the modal overlay opening
    * @return {Step} The newly created Step instance
    */
   constructor(tour, options = {}) {

--- a/src/js/utils/overlay-path.js
+++ b/src/js/utils/overlay-path.js
@@ -1,0 +1,29 @@
+/**
+ * Generates the svg path data for a rounded rectangle overlay
+ * @param {Object} dimension - Dimensions of rectangle.
+ * @param {number} width - Width.
+ * @param {number} height - Height.
+ * @param {number} [x=0] - Offset from top left corner in x axis. default 0.
+ * @param {number} [y=0] - Offset from top left corner in y axis. default 0.
+ * @param {number} [r=0] - Corner Radius. Keep this smaller than  half of width or height.
+ * @returns {string} - Rounded rectangle overlay path data.
+ */
+export function makeOverlayPath({ width, height, x = 0, y = 0, r = 0 }) {
+  const { innerWidth: w, innerHeight: h } = window;
+
+  return `M${w},${h}\
+H0\
+V0\
+H${w}\
+V${h}\
+Z\
+M${x + r},${y}\
+a${r},${r},0,0,0-${r},${r}\
+V${height + y - r}\
+a${r},${r},0,0,0,${r},${r}\
+H${width + x - r}\
+a${r},${r},0,0,0,${r}-${r}\
+V${y + r}\
+a${r},${r},0,0,0-${r}-${r}\
+Z`;
+}

--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -130,6 +130,11 @@ declare namespace Step {
     modalOverlayOpeningPadding?: number;
 
     /**
+     * An amount of border radius to add around the modal overlay opening
+     */
+    modalOverlayOpeningRadius?: number;
+
+    /**
      * Extra [options to pass to Popper]{@link https://popper.js.org/docs/v2/}
      */
     popperOptions?: object;

--- a/test/unit/components/shepherd-modal.spec.js
+++ b/test/unit/components/shepherd-modal.spec.js
@@ -28,13 +28,13 @@ describe('components/ShepherdModal', () => {
 
       let modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 20 20 H 520 V 270 H 20 L 20 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM20,20a0,0,0,0,0-0,0V270a0,0,0,0,0,0,0H520a0,0,0,0,0,0-0V20a0,0,0,0,0-0-0Z');
 
       await modalComponent.closeModalOpening();
 
       modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 0 0 H 0 V 0 H 0 L 0 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM0,0a0,0,0,0,0-0,0V0a0,0,0,0,0,0,0H0a0,0,0,0,0,0-0V0a0,0,0,0,0-0-0Z');
 
       modalComponent.$destroy();
     });
@@ -51,13 +51,13 @@ describe('components/ShepherdModal', () => {
       });
 
       let modalPath = modalComponent.getElement().querySelector('path');
-      expect(modalPath).toHaveAttribute('d', 'M 0 0 H 0 V 0 H 0 L 0 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+      expect(modalPath).toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM0,0a0,0,0,0,0-0,0V0a0,0,0,0,0,0,0H0a0,0,0,0,0,0-0V0a0,0,0,0,0-0-0Z');
 
       await modalComponent.closeModalOpening();
 
       modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 0 0 H 0 V 0 H 0 L 0 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM0,0a0,0,0,0,0-0,0V0a0,0,0,0,0,0,0H0a0,0,0,0,0,0-0V0a0,0,0,0,0-0-0Z');
 
       await modalComponent.positionModalOpening({
         getBoundingClientRect() {
@@ -72,7 +72,7 @@ describe('components/ShepherdModal', () => {
 
       modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 20 20 H 520 V 270 H 20 L 20 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM20,20a0,0,0,0,0-0,0V270a0,0,0,0,0,0,0H520a0,0,0,0,0,0-0V20a0,0,0,0,0-0-0Z');
 
       modalComponent.$destroy();
     });
@@ -87,7 +87,7 @@ describe('components/ShepherdModal', () => {
       });
 
       let modalPath = modalComponent.getElement().querySelector('path');
-      expect(modalPath).toHaveAttribute('d', 'M 0 0 H 0 V 0 H 0 L 0 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+      expect(modalPath).toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM0,0a0,0,0,0,0-0,0V0a0,0,0,0,0,0,0H0a0,0,0,0,0,0-0V0a0,0,0,0,0-0-0Z');
 
       await modalComponent.positionModalOpening({
         getBoundingClientRect() {
@@ -102,7 +102,43 @@ describe('components/ShepherdModal', () => {
 
       modalPath = modalComponent.getElement().querySelector('path');
       expect(modalPath)
-        .toHaveAttribute('d', 'M 10 10 H 530 V 280 H 10 L 10 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+        .toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM10,10a0,0,0,0,0-0,0V280a0,0,0,0,0,0,0H530a0,0,0,0,0,0-0V10a0,0,0,0,0-0-0Z');
+
+      modalComponent.$destroy();
+    });
+
+    it('sets the correct attributes when positioning modal opening with border radius', async() => {
+      const modalComponent = new ShepherdModal({
+        target: document.body,
+        props:
+            {
+              classPrefix
+            }
+      });
+
+      let modalPath = modalComponent.getElement().querySelector('path');
+      expect(modalPath).toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM0,0a0,0,0,0,0-0,0V0a0,0,0,0,0,0,0H0a0,0,0,0,0,0-0V0a0,0,0,0,0-0-0Z');
+
+      await modalComponent.closeModalOpening();
+
+      modalPath = modalComponent.getElement().querySelector('path');
+      expect(modalPath)
+        .toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM0,0a0,0,0,0,0-0,0V0a0,0,0,0,0,0,0H0a0,0,0,0,0,0-0V0a0,0,0,0,0-0-0Z');
+
+      await modalComponent.positionModalOpening({
+        getBoundingClientRect() {
+          return {
+            height: 250,
+            x: 20,
+            y: 20,
+            width: 500
+          };
+        }
+      }, null, 0, 10);
+
+      modalPath = modalComponent.getElement().querySelector('path');
+      expect(modalPath)
+        .toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM30,20a10,10,0,0,0-10,10V260a10,10,0,0,0,10,10H510a10,10,0,0,0,10-10V30a10,10,0,0,0-10-10Z');
 
       modalComponent.$destroy();
     });
@@ -136,7 +172,7 @@ describe('components/ShepherdModal', () => {
       }, 0);
 
       const modalPath = modalComponent.getElement().querySelector('path');
-      expect(modalPath).toHaveAttribute('d', 'M 10 100 H 510 V 350 H 10 L 10 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+      expect(modalPath).toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM10,100a0,0,0,0,0-0,0V350a0,0,0,0,0,0,0H510a0,0,0,0,0,0-0V100a0,0,0,0,0-0-0Z');
 
       modalComponent.$destroy();
     });
@@ -170,7 +206,7 @@ describe('components/ShepherdModal', () => {
       }, 0);
 
       const modalPath = modalComponent.getElement().querySelector('path');
-      expect(modalPath).toHaveAttribute('d', 'M 10 100 H 510 V 350 H 10 L 10 0 Z M 0 0 H 1024 V 768 H 0 L 0 0 Z');
+      expect(modalPath).toHaveAttribute('d', 'M1024,768H0V0H1024V768ZM10,100a0,0,0,0,0-0,0V350a0,0,0,0,0,0,0H510a0,0,0,0,0,0-0V100a0,0,0,0,0-0-0Z');
 
       modalComponent.$destroy();
     });


### PR DESCRIPTION
The issue was we were not able to give rounded borders to the highlighted elements and no convincing methods were found in the docs or issues whatsoever.

The PR contains the ability to pass `modalOverlayOpeningRadius` as a parameter in options of the step to add rounded corners with customized radius. Please go ahead and review the PR. I would be happy to solve any doubts or changes if required.

The feature includes:

- Added `modalOverlayOpeningRadius` as an optional parameter in step.d.ts / step.js.
- Added the entry in the wiki for 02-usage.md.
- Modified SVG building to support `modalOverlayOpeningRadius`
 and necessary code changes to accept `modalOverlayOpeningRadius` just like `modalOverlayOpeningPadding` feature in shepherd-model.svelte.
- Modified Unit Tests to support `modalOverlayOpeningRadius` and added a new test for the same feature.

Thanks with regards.


Based on [this](https://github.com/shipshapecode/shepherd/pull/729) PR and complete it