### PR TITLE
🐛 Remove overlay container on destroy

### DIFF
--- a/landing/js/welcome.js
+++ b/landing/js/welcome.js
@@ -5,49 +5,6 @@
     var shepherd = setupShepherd();
     setTimeout(function() {
       shepherd.start();
-
-      setTimeout(function () {
-        const other = new Shepherd.Tour({
-          defaultStepOptions: {
-            cancelIcon: {
-              enabled: true
-            },
-            classes: 'class-1 class-2',
-            scrollTo: {
-              behavior: 'smooth',
-              block: 'center'
-            }
-          },
-          // This should add the first tour step
-          steps: [
-            {
-              text: '\n         <p>\n           Shepherd is a JavaScript library for guiding users through your app.\n           It uses <a href="https://popper.js.org/" data-test-popper-link>Popper.js</a>,\n           another open source library, to render dialogs for each tour "step".\n         </p>\n        \n         <p>\n           Among many things, Popper makes sure your steps never end up off screen or cropped by an overflow.\n           (Try resizing your browser to see what we mean.)\n         </p>\n',
-              attachTo: {
-                element: '.hero-welcome',
-                on: 'bottom'
-              },
-              buttons: [
-                {
-                  action: function () {
-                    return this.cancel();
-                  },
-                  secondary: true,
-                  text: 'Exit'
-                },
-                {
-                  action: function () {
-                    return this.next();
-                  },
-                  text: 'Next'
-                }
-              ],
-              id: 'welcome'
-            }
-          ],
-          useModalOverlay: true
-        });
-        other.start();
-      }, 400);
     }, 400);
   }
 

--- a/landing/js/welcome.js
+++ b/landing/js/welcome.js
@@ -5,6 +5,49 @@
     var shepherd = setupShepherd();
     setTimeout(function() {
       shepherd.start();
+
+      setTimeout(function () {
+        const other = new Shepherd.Tour({
+          defaultStepOptions: {
+            cancelIcon: {
+              enabled: true
+            },
+            classes: 'class-1 class-2',
+            scrollTo: {
+              behavior: 'smooth',
+              block: 'center'
+            }
+          },
+          // This should add the first tour step
+          steps: [
+            {
+              text: '\n         <p>\n           Shepherd is a JavaScript library for guiding users through your app.\n           It uses <a href="https://popper.js.org/" data-test-popper-link>Popper.js</a>,\n           another open source library, to render dialogs for each tour "step".\n         </p>\n        \n         <p>\n           Among many things, Popper makes sure your steps never end up off screen or cropped by an overflow.\n           (Try resizing your browser to see what we mean.)\n         </p>\n',
+              attachTo: {
+                element: '.hero-welcome',
+                on: 'bottom'
+              },
+              buttons: [
+                {
+                  action: function () {
+                    return this.cancel();
+                  },
+                  secondary: true,
+                  text: 'Exit'
+                },
+                {
+                  action: function () {
+                    return this.next();
+                  },
+                  text: 'Next'
+                }
+              ],
+              id: 'welcome'
+            }
+          ],
+          useModalOverlay: true
+        });
+        other.start();
+      }, 400);
     }, 400);
   }
 

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -21,7 +21,7 @@ export class Step extends Evented {
    * @param {Object} options.arrow Whether to display the arrow for the tooltip or not.
    * @param {Object} options.attachTo What element the step should be attached to on the page.
    * It should be an object with the properties `element` and `on`, where `element` is an element selector string
-   * or a DOM element and `on` is the optional direction to place the Tippy tooltip.
+   * or a DOM element and `on` is the optional direction to place the Popper tooltip.
    *
    * ```js
    * const new Step(tour, {

--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -286,7 +286,15 @@ export class Tour extends Evented {
     Shepherd.activeTour = null;
     this.trigger('inactive', { tour: this });
 
-    this.modal.hide();
+    if (this.modal) {
+      const modalContainer = document.querySelector('.shepherd-modal-overlay-container');
+
+      if (modalContainer) {
+        modalContainer.remove();
+      }
+
+      this.modal = null;
+    }
 
     // Focus the element that was focused before the tour started
     if (isElement(this.focusedElBeforeOpen)) {

--- a/test/unit/components/shepherd-modal.spec.js
+++ b/test/unit/components/shepherd-modal.spec.js
@@ -303,9 +303,21 @@ describe('components/ShepherdModal', () => {
     it('appends shepherdModalOverlayContainer to DOM when it does not exist', () => {
       expect(document.querySelectorAll('.shepherd-modal-overlay-container').length).toBe(0);
 
-      new Tour({ useModalOverlay: true });
+      const tour = new Tour({ useModalOverlay: true });
 
       expect(document.querySelectorAll('.shepherd-modal-overlay-container').length).toBe(1);
+
+      tour.complete();
+    });
+
+    it('removes shepherdModalOverlayContainer from DOM when it is complete', () => {
+      const tour = new Tour({ useModalOverlay: true });
+
+      expect(document.querySelectorAll('.shepherd-modal-overlay-container').length).toBe(1);
+
+      tour.complete();
+
+      expect(document.querySelectorAll('.shepherd-modal-overlay-container').length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
This cleans up the overlay containers on destroy to stop polluting the DOM further. 

closes #663 