### PR TITLE
Update shepherd-button.svelte to allow HTML

### DIFF
--- a/src/js/components/shepherd-button.svelte
+++ b/src/js/components/shepherd-button.svelte
@@ -61,5 +61,5 @@
   on:click={action}
   tabindex="0"
 >
-    {text}
+    {@html text}
 </button>


### PR DESCRIPTION
Make shepherd-button capable of displaying HTML.  Without @html Svelte converts the value into a textNode, which escapes HTML. 

#865 