### PR TITLE
🐛 Fix centered sizing and add max height defaults for text

### DIFF
--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -120,7 +120,7 @@
     opacity: 0;
     outline: none;
     transition: opacity 0.3s;
-    width: 400px;
+    width: 100%;
     z-index: 9999;
   }
 

--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -120,6 +120,7 @@
     opacity: 0;
     outline: none;
     transition: opacity 0.3s;
+    width: 400px;
     z-index: 9999;
   }
 

--- a/src/js/components/shepherd-text.svelte
+++ b/src/js/components/shepherd-text.svelte
@@ -24,6 +24,8 @@
     color: rgba(0, 0, 0, 0.75);
     font-size: 1rem;
     line-height: 1.3em;
+    max-height: 30vh;
+    overflow: scroll;
     padding: 0.75em;
   }
 


### PR DESCRIPTION
closes: #837 

mobile:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/706378/79280979-a64c3e80-7e66-11ea-9dc7-92ea275877f8.png">

and desktop:
<img width="615" alt="image" src="https://user-images.githubusercontent.com/706378/79280989-af3d1000-7e66-11ea-98d0-b4062ad76e8a.png">
