### PR TITLE
🐛 Create deep copy of tour options to make immutable

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -297,7 +297,8 @@ export class Step extends Evented {
       {
         arrow: true
       },
-      tourOptions,
+      // make a deep copy in order to prevent mutation on the source
+      JSON.parse(JSON.stringify(tourOptions)),
       options
     );
 

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -292,13 +292,13 @@ export class Step extends Evented {
   _setOptions(options = {}) {
     const tourOptions =
       this.tour && this.tour.options && this.tour.options.defaultStepOptions;
+    const tourOptionsCopy = tourOptions ? JSON.parse(JSON.stringify(tourOptions)) : {};
 
     this.options = Object.assign(
       {
         arrow: true
       },
-      // make a deep copy in order to prevent mutation on the source
-      JSON.parse(JSON.stringify(tourOptions)),
+      tourOptionsCopy,
       options
     );
 

--- a/test/unit/tour.spec.js
+++ b/test/unit/tour.spec.js
@@ -14,7 +14,8 @@ describe('Tour | Top-Level Class', function() {
 
   const defaultStepOptions = {
     classes: DEFAULT_STEP_CLASS,
-    scrollTo: true
+    scrollTo: true,
+    popperOptions: {}
   };
 
   afterEach(() => {
@@ -29,11 +30,18 @@ describe('Tour | Top-Level Class', function() {
     });
 
     it('returns the default options on the instance', function() {
-      instance = new Shepherd.Tour({ defaultStepOptions });
+      instance = new Shepherd.Tour({
+        defaultStepOptions, steps: [{
+          scrollTo: false
+        }]
+      });
+
+      instance.start();
 
       expect(instance.options.defaultStepOptions).toEqual({
         classes: DEFAULT_STEP_CLASS,
-        scrollTo: true
+        scrollTo: true,
+        popperOptions: {}
       });
     });
 


### PR DESCRIPTION
closes #915

The shallow copy created via `Object.assign` was causing the original tour `defaultStepOptions` to be mutated by step options. More info: 

Object.assign({})
Can only make shallow copies of objects so it will only work in a single level (first level) of the object reference. 

Object spread:
Object spread does a 'shallow copy' of the object. Only the object itself is cloned, while "nested instances are not cloned". This results in mutated nested objects.

JSON.parse(JSON.stringify()):
This is going to work fine as long as your Objects and the nested Objects "only contains primitives". This is going to fail when it is passing functions on values such as `beforeShowPromise`.

@rwwagner90 otherwise, we're going to need to use a much more complex deep merge utility, whether written ourselves or something like https://github.com/kolodny/immutability-helper