### PR TITLE
Fix defaultStepOptions.popperOptions issues

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   arrowParens: 'always',
+  trailingComma: 'none',
   singleQuote: true
 };

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -108,21 +108,36 @@ export function getPopperOptions(attachToOptions, step) {
     target = attachToOptions.element;
   }
 
-  if (step.options.popperOptions) {
+  const defaultStepOptions =
+    step.tour && step.tour.options && step.tour.options.defaultStepOptions;
+
+  if (defaultStepOptions) {
+    popperOptions = _mergeModifiers(defaultStepOptions, popperOptions);
+  }
+
+  popperOptions = _mergeModifiers(step.options, popperOptions);
+
+  return { element: step.el, popperOptions, target };
+}
+
+function _mergeModifiers(stepOptions, popperOptions) {
+  if (stepOptions.popperOptions) {
     if (
-      step.options.popperOptions.modifiers &&
-      step.options.popperOptions.modifiers.length > 0
+      stepOptions.popperOptions.modifiers &&
+      stepOptions.popperOptions.modifiers.length > 0
     ) {
-      const names = step.options.popperOptions.modifiers.map((mod) => mod.name);
+      const names = stepOptions.popperOptions.modifiers.map((mod) => mod.name);
       const filteredModifiers = popperOptions.modifiers.filter(
         (mod) => !names.includes(mod.name)
       );
 
-      popperOptions.modifiers = Array.from(new Set([...filteredModifiers, ...step.options.popperOptions.modifiers]));
+      popperOptions.modifiers = Array.from(
+        new Set([...filteredModifiers, ...stepOptions.popperOptions.modifiers])
+      );
     }
 
-    popperOptions = Object.assign(step.options.popperOptions, popperOptions);
+    popperOptions = Object.assign(stepOptions.popperOptions, popperOptions);
   }
 
-  return { element: step.el, popperOptions, target };
+  return popperOptions;
 }

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -118,7 +118,7 @@ describe('Tour | Step', () => {
     it('adds a step modifer to default modifiers', () => {
       // this will add the default `preventOverflow` modifier before showing
       testStep.show();
-      expect(testStep.options.popperOptions.modifiers.length).toBe(3);
+      expect(testStep.options.popperOptions.modifiers.length).toBe(4);
     });
 
     it('allows the step to override a previously defined modifier', () => {

--- a/test/unit/tour.spec.js
+++ b/test/unit/tour.spec.js
@@ -14,7 +14,8 @@ describe('Tour | Top-Level Class', function() {
 
   const defaultStepOptions = {
     classes: DEFAULT_STEP_CLASS,
-    scrollTo: true
+    scrollTo: true,
+    popperOptions: {}
   };
 
   afterEach(() => {
@@ -29,11 +30,16 @@ describe('Tour | Top-Level Class', function() {
     });
 
     it('returns the default options on the instance', function() {
-      instance = new Shepherd.Tour({ defaultStepOptions });
+      instance = new Shepherd.Tour({
+        defaultStepOptions, steps: [{
+          scrollTo: false
+        }]
+      });
 
       expect(instance.options.defaultStepOptions).toEqual({
         classes: DEFAULT_STEP_CLASS,
-        scrollTo: true
+        scrollTo: true,
+        popperOptions: {}
       });
     });
 


### PR DESCRIPTION
Previously, we were not merging in `defaultStepOptions` modifiers at all because they were overwritten by the step. This adds the same treatment for `defaultStepOptions.popperOptions` as `step.options.popperOptions`. 

This issue is caused by setup being in a weird order. Rather than setting up these options at different times, we should probably fix the `_setOptions` call to do this setup work, so the merging is not clobbering itself.

Closes #919 
Closes #915 