### PR TITLE
Deep copy defaultStepOptions

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -290,8 +290,10 @@ export class Step extends Evented {
    * @private
    */
   _setOptions(options = {}) {
-    const tourOptions =
+    let tourOptions =
       this.tour && this.tour.options && this.tour.options.defaultStepOptions;
+
+    tourOptions = tourOptions ? JSON.parse(JSON.stringify(tourOptions)) : {};
 
     this.options = Object.assign(
       {


### PR DESCRIPTION
This avoids keeping a polluted state around when setting up multiple step options.

Fixes #915