### PR TITLE
cookbook - progress bar code snippet fix  to show in all steps

### DIFF
--- a/docs-src/tutorials/04-cookbook.md
+++ b/docs-src/tutorials/04-cookbook.md
@@ -34,12 +34,12 @@ being show.
 ```javascript
 when: {
   show() {
-    const header = document.querySelector('.shepherd-header');
+    const currentStepElement = shepherd.currentStep.el;
+    const header = currentStepElement.querySelector('.shepherd-header');
     const progress = document.createElement('span');
     progress.style['margin-right'] = '315px';
-
     progress.innerText = `${shepherd.steps.indexOf(shepherd.currentStep) + 1}/${shepherd.steps.length}`;
-    header.insertBefore(progress, document.querySelector('.shepherd-cancel-icon'));        
+    header.insertBefore(progress, currentStepElement.querySelector('.shepherd-cancel-icon'));        
   }
 }
 ```


### PR DESCRIPTION
Since `document.querySlector` is used, the `document.querySelector('.shepherd-header')` would still give the header of step 1 even if it is executed for step 2. Hence changed it to use step element 'el' instead of document.