### PR TITLE
Require attachTo.on to show arrow

### DIFF
--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -202,7 +202,7 @@
   role="dialog"
   tabindex="0"
 >
-    {#if step.options.arrow && step.options.attachTo && step.options.attachTo.element}
+    {#if step.options.arrow && step.options.attachTo && step.options.attachTo.element && step.options.attachTo.on}
       <div class="shepherd-arrow" data-popper-arrow></div>
     {/if}
   <ShepherdContent


### PR DESCRIPTION
According to the docs, we should be hiding the arrow if you do not define `attachTo.on` so this should fix that issue.

Fixes #978 