### PR TITLE
Added the correct this context to StepOption 'when' functions

### DIFF
--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -279,7 +279,7 @@ declare namespace Step {
   }
 
   interface StepOptionsWhen {
-    [key: string]: (() => void);
+    [key: string]: ((this: Step) => void);
   }
 }
 


### PR DESCRIPTION
Update step.d.ts
With accordance to https://github.com/shipshapecode/shepherd/blob/ad5b9b0daa3a2db1a507b70f6f4d6b5620add40d/src/js/step.js#L332 the "this" context is set to the Step