### PR TITLE
Step Element Target Action

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -234,6 +234,22 @@ export class Step extends Evented {
   }
 
   /**
+   * Returns the element for the step
+   * @return {HTMLElement|null|undefined} The element instance. undefined if it has never been shown, null if it has been destroyed
+   */
+  getElement() {
+    return this.el;
+  }
+
+  /**
+   * Returns the target for the step
+   * @return {HTMLElement|null|undefined} The element instance. undefined if it has never been shown, null if query string has not been found
+   */
+  getTarget() {
+    return this.target;
+  }
+
+  /**
    * Creates Shepherd element for step based on options
    *
    * @return {Element} The DOM element for the step tooltip

--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -61,6 +61,18 @@ declare class Step extends Evented {
    * @param {Step.StepOptions} options to be updated
    */
   updateStepOptions(options: Step.StepOptions): void;
+
+  /**
+   * Returns the element for the step
+   * @return The element instance. undefined if it has never been shown, null if it has been destroyed
+   */
+  getElement(): HTMLElement | null | undefined
+
+  /**
+   * Returns the target for the step
+   * @returns The element instance. undefined if it has never been shown, null if query string has not been found
+   */
+  getTarget(): HTMLElement | null | undefined
 }
 
 declare namespace Step {
@@ -231,7 +243,7 @@ declare namespace Step {
      * }
      * ```
      */
-    action?: (() => void);
+    action?: ((this: Tour) => void);
 
     /**
      * Extra classes to apply to the `<a>`


### PR DESCRIPTION
Hey @rwwagner90 Sorry, I have been some time, I have had family duties and also it seems I am being super dumb so it's really slowing me down.

I have never tried to do advanced things with JSdocs, so I am failing to see how I can nicely add the 'this' context to JSDocs.. I am more a typescript person who has dabbled with JSDocs in the past..
So I have utterly failed to see how to assign the context without making it look like a function argument, so.. I left it as is. (Sorry)

The second thing I have been struggling with is double checking on what `getTarget()` could return..

I was destroying my brain going around in circles over and over going down dead ends and all sorts trying to find where this.target was assigned in `step.js`.. 

And then I finally found `step.target` in `general.js` and `parseAttachTo` 

Added getElement to Step class and typescript definition
Added getTarget to Step class and typescript definition
Added 'this' context to Action callback typescript definition

Though, I thought it best to note, it is technically possible to get SVGElements back and not just HTMLElements.. We have some Typescripting in our own projects that deal with that, but with how limiting it is with JSDocs already, I thought best to try and keep it simple and not defer too far from the JSDocs in the typescript definition. 