### PR TITLE
Add Edge 18 to browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -4,3 +4,4 @@ last 2 Chrome versions
 last 2 Firefox versions
 last 2 Safari versions
 last 2 Edge versions
+Edge 18


### PR DESCRIPTION
- Enables transpilation of object property spread
- Required for (old) EdgeHTML 18 compatibility
- Fixes #1023