### PR TITLE
_scrollTo works with SVGElement too

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -287,7 +287,7 @@ export class Step extends Evented {
     if (isFunction(this.options.scrollToHandler)) {
       this.options.scrollToHandler(element);
     } else if (
-      isElement(element) &&
+      element instanceof Element &&
       typeof element.scrollIntoView === 'function'
     ) {
       element.scrollIntoView(scrollToOptions);


### PR DESCRIPTION
Fixes #1027 using instanceof Element to target both HTMLElement and SVGElement