### PR TITLE
add Step.id to typings, fix tour.getById() typing

### DIFF
--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -13,6 +13,11 @@ declare class Step extends Evented {
    * @return The newly created Step instance
    */
   constructor(tour: Tour, options: Step.StepOptions);//TODO superheri Note: Return on constructor is not possible in typescript. Could this be possible to make this the same for the constructor of the Step class?
+   
+  /**
+   * The string used as the `id` for the step.
+   */
+  id: string;
 
   /**
    * Cancel the tour

--- a/src/types/tour.d.ts
+++ b/src/types/tour.d.ts
@@ -45,9 +45,9 @@ declare class Tour extends Evented {
   /**
    * Gets the step from a given id
    * @param id The id of the step to retrieve
-   * @return The step corresponding to the `id`
+   * @return The step corresponding to the `id` or null if no step matches the `id`
    */
-  getById(id: number | string): Step;
+  getById(id: number | string): Step | null;
 
   /**
    * Gets the current step


### PR DESCRIPTION
Exposes the `id` property of `Step` in TypeScript.
Fix the typing of `Tour.getById()` which can return null if given an `id` that's not in the tour.