### PR TITLE
Add missing types for Step.options and Tour.steps

### DIFF
--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -67,6 +67,11 @@ declare class Step extends Evented {
   isOpen(): boolean;
 
   /**
+   * Options for the step
+   */
+  options: Step.StepOptions;
+
+  /**
    * Wraps `_show` and ensures `beforeShowPromise` resolves before calling show
    * @return Promise
    */

--- a/src/types/tour.d.ts
+++ b/src/types/tour.d.ts
@@ -88,6 +88,11 @@ declare class Tour extends Evented {
    * Start the tour
    */
   start(): void;
+
+  /**
+   * An array of Step instances
+   */
+  steps: Array<Step>;
 }
 
 declare namespace Tour {


### PR DESCRIPTION
This PR adds types for:
* the `options` property of the `Step` class
* the `steps` property of the `Tour` class