### PR TITLE
Add multiple events example to docs

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -84,6 +84,14 @@ event handlers a `tour` key pointing to the instance which fired the event:
 - `active`
 - `inactive`
 
+For multiple events, you can use something like:
+
+```javascript
+['close', 'cancel'].forEach(event => shepherd.on(event, () => {
+   // some code here
+}));
+```
+
 ##### Current Tour
 
 The global `Shepherd` includes a property which is always set to the currently active tour, or null if there is no active tour:


### PR DESCRIPTION
I was searching for a way to call a function for multiple events and found #27 , that discussed a feature like this but ended up being closed in favor of using javascript directly.
I think it's a good idea to add this to the docs, so people can find it more easily in the future.

Thanks @BrianSipple for the solution!