### PR TITLE
shift + tab handled

### DIFF
--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -79,7 +79,7 @@
         }
         // Backward tab
         if (e.shiftKey) {
-          if (document.activeElement === firstFocusableElement) {
+          if (document.activeElement === firstFocusableElement || document.activeElement.hasAttribute("data-popper-placement")) {
             e.preventDefault();
             lastFocusableElement.focus();
           }

--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -79,7 +79,7 @@
         }
         // Backward tab
         if (e.shiftKey) {
-          if (document.activeElement === firstFocusableElement || document.activeElement.hasAttribute("data-popper-placement")) {
+          if (document.activeElement === firstFocusableElement || document.activeElement.classList.contains('shepherd-element')) {
             e.preventDefault();
             lastFocusableElement.focus();
           }


### PR DESCRIPTION
This pull request closes #1076 by adding an additional check on `data-popper-placement` attribute on `document.activeElement` when `shiftKey` is pressed