### PR TITLE
docs: Fix simple typo, unminifed -> unminified

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -70,7 +70,7 @@ plugins.push(filesize());
 plugins.push(visualizer());
 
 const rollupBuilds = [
-  // Generate unminifed bundle
+  // Generate unminified bundle
   {
     input: './src/js/shepherd.js',
 


### PR DESCRIPTION
There is a small typo in rollup.config.js.

Should read `unminified` rather than `unminifed`.

