### PR TITLE
Add `stepsContainer` option, allowing users to specify rendering target for step elements

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -118,6 +118,7 @@ const myTour = new Shepherd.Tour(options);
 - `defaultStepOptions`: Default options for Steps created through `addStep`
 - `exitOnEsc`: Exiting the tour with the escape key will be enabled unless this is explicitly set to `false`.
 - `keyboardNavigation`: Navigating the tour via left and right arrow keys will be enabled unless this is explicitly set to `false`.
+- `stepsContainer` An optional container element for the steps. If not set, the steps will be appended to `document.body`.
 - `modalContainer` An optional container element for the modal. If not set, the modal will be appended to `document.body`.
 - `steps`: An array of step options objects or Step instances to initialize the tour with.
 - `tourName`: An optional "name" for the tour. This will be appended to the the tour's

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -256,7 +256,7 @@ export class Step extends Evented {
     const labelId = `${this.id}-label`;
 
     this.shepherdElementComponent = new ShepherdElement({
-      target: document.body,
+      target: this.tour.options.stepsContainer || document.body,
       props: {
         classPrefix: this.classPrefix,
         descriptionId,

--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -23,6 +23,8 @@ export class Tour extends Evented {
    * set to false.
    * @param {boolean} options.keyboardNavigation Navigating the tour via left and right arrow keys will be enabled
    * unless this is explicitly set to false.
+   * @param {HTMLElement} options.stepsContainer An optional container element for the steps.
+   * If not set, the steps will be appended to `document.body`.
    * @param {HTMLElement} options.modalContainer An optional container element for the modal.
    * If not set, the modal will be appended to `document.body`.
    * @param {object[] | Step[]} options.steps An array of step options objects or Step instances to initialize the tour with

--- a/src/types/tour.d.ts
+++ b/src/types/tour.d.ts
@@ -130,6 +130,16 @@ declare namespace Tour {
     keyboardNavigation?: boolean;
 
     /**
+     * An optional container element for the steps. If not set, the steps will be appended to document.body.
+     */
+    stepsContainer?: HTMLElement,
+
+    /**
+     * An optional container element for the modal. If not set, the modal will be appended to document.body.
+     */
+    modalContainer?: HTMLElement,
+
+    /**
      * An array of step options objects or Step instances to initialize the tour with
      */
     steps?: Array<object> | Array<Step>;

--- a/test/unit/tour.spec.js
+++ b/test/unit/tour.spec.js
@@ -502,6 +502,28 @@ describe('Tour | Top-Level Class', function() {
 
       document.body.removeChild(div);
     });
+
+    it('renders step in stepsContainer', () => {
+      const stepsContainer = document.createElement('div');
+      stepsContainer.setAttribute('id', 'customStepTarget');
+      document.body.appendChild(stepsContainer);
+      expect(stepsContainer).toBeInTheDocument();
+
+      instance = new Shepherd.Tour({
+        stepsContainer,
+        defaultStepOptions
+      });
+
+      const step = instance.addStep({
+        title: 'This is a test step for our tour'
+      });
+
+      instance.start();
+
+      const stepElement = step.getElement();
+
+      expect(stepsContainer.contains(stepElement)).toBe(true);
+    });
   });
 
   describe('shepherdModalOverlayContainer', function() {
@@ -528,6 +550,28 @@ describe('Tour | Top-Level Class', function() {
       instance.complete();
 
       expect(document.querySelector('.shepherd-modal-overlay-container')).not.toBeInTheDocument();
+    });
+
+    it('renders modal in modalContainer', () => {
+      const modalContainer = document.createElement('div');
+      modalContainer.setAttribute('id', 'customModalTarget');
+      document.body.appendChild(modalContainer);
+      expect(modalContainer).toBeInTheDocument();
+
+      instance = new Shepherd.Tour({
+        modalContainer,
+        useModalOverlay: true
+      });
+
+      instance.addStep({
+        title: 'This is a test step for our tour'
+      });
+
+      instance.start();
+
+      const modalElement = instance.modal.getElement();
+
+      expect(modalContainer.contains(modalElement)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Hi! This PR adds a new option to TourOptions: `stepsContainer`, which mimics the behaviour of `modalContainer`. Thanks to this new configuration, it is now possible to specify the render target of step elements, as discussed [here](https://github.com/shipshapecode/shepherd/issues/1175).

Also added missing types, and some tests for `modalContainer` while at it.

Related:
https://github.com/shipshapecode/shepherd/issues/1175
https://github.com/shipshapecode/shepherd/pull/1075 (which is almost the same thing, but my PR is a bit more complete)