### PR TITLE
Implement lazy evaluation of `attachTo.element`

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -164,7 +164,7 @@ created.
   - `Function` to be executed when the step is built. It must return one the two options above.
 - `title`: The step's title. It becomes an `h3` at the top of the step.
 - `attachTo`: The element the step should be attached to on the page. An object with properties `element` and `on`.
-  - `element`: An element selector string or a DOM element.
+  - `element`: An element selector string, a DOM element, or a function (returning a selector, a DOM element, `null` or `undefined`). 
   - `on`: The optional direction to place the Popper tooltip relative to the element.
     - Possible string values: 'auto', 'auto-start', 'auto-end', 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'
 
@@ -175,9 +175,13 @@ const new Step(tour, {
 });
 ```
 
-If you don’t specify an attachTo the element will appear in the middle of the screen.
+If you don’t specify an `attachTo` the element will appear in the middle of the screen. The same will happen if your 
+`attachTo.element` callback returns `null`, `undefined`, or a selector that does not exist in the DOM.
+
 If you omit the `on` portion of `attachTo`, the element will still be highlighted, but the tooltip will appear
 in the middle of the screen, without an arrow pointing to the target.
+
+If the element to highlight does not yet exist while instantiating tour steps, you may use lazy evaluation by supplying a function to `attachTo.element`. The function will be called in the `before-show` phase.
 - `beforeShowPromise`: A function that returns a promise. When the promise resolves, the rest of the `show` code for
 the step will execute. For example:
   ```javascript

--- a/landing/css/welcome.css
+++ b/landing/css/welcome.css
@@ -377,7 +377,6 @@ pre {
 button {
   background-color: transparent;
   background-image: none;
-  padding: 0;
 }
 
 /**
@@ -479,6 +478,10 @@ textarea {
   resize: vertical;
 }
 
+input::-ms-input-placeholder, textarea::-ms-input-placeholder {
+  color: #a0aec0;
+}
+
 input::placeholder,
 textarea::placeholder {
   color: #a0aec0;
@@ -578,10 +581,6 @@ video {
   height: auto;
 }
 
-/*tailwind start components */
-
-/*tailwind end components */
-
 .bg-navy {
   --bg-opacity: 1;
   background-color: #16202D;
@@ -638,6 +637,10 @@ video {
 
 .flex {
   display: flex;
+}
+
+.table {
+  display: table;
 }
 
 .flex-col {
@@ -858,6 +861,37 @@ video {
 
 .z-20 {
   z-index: 20;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@keyframes pulse {
+  50% {
+    opacity: .5;
+  }
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    animation-timing-function: cubic-bezier(0.8,0,1,1);
+  }
+
+  50% {
+    transform: none;
+    animation-timing-function: cubic-bezier(0,0,0.2,1);
+  }
 }
 
 html, body {
@@ -1094,6 +1128,9 @@ pre {
   border-bottom-style: solid;
 }
 
+@media (min-width: 640px) {
+}
+
 @media (min-width: 768px) {
   .md\:justify-between {
     justify-content: space-between;
@@ -1184,4 +1221,7 @@ pre {
   .lg\:w-1\/3 {
     width: 33.333333%;
   }
+}
+
+@media (min-width: 1280px) {
 }

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -1,5 +1,5 @@
 import { createPopper } from '@popperjs/core';
-import { isString } from './type-check';
+import { isFunction, isString } from './type-check';
 import { makeCenteredPopper } from './popper-options';
 
 /**
@@ -16,9 +16,9 @@ export function normalizePrefix(prefix) {
 }
 
 /**
- * Checks if options.attachTo.element is a string, and if so, tries to find the element
+ * Resolves attachTo options, converting element option value to a qualified HTMLElement.
  * @param {Step} step The step instance
- * @returns {{element, on}}
+ * @returns {{}|{element, on}}
  * `element` is a qualified HTML Element
  * `on` is a string position value
  */
@@ -26,11 +26,16 @@ export function parseAttachTo(step) {
   const options = step.options.attachTo || {};
   const returnOpts = Object.assign({}, options);
 
-  if (isString(options.element)) {
+  if (isFunction(returnOpts.element)) {
+    // Bind the callback to step so that it has access to the object, to enable running additional logic
+    returnOpts.element = returnOpts.element.call(step);
+  }
+
+  if (isString(returnOpts.element)) {
     // Can't override the element in user opts reference because we can't
     // guarantee that the element will exist in the future.
     try {
-      returnOpts.element = document.querySelector(options.element);
+      returnOpts.element = document.querySelector(returnOpts.element);
     } catch (e) {
       // TODO
     }
@@ -45,6 +50,16 @@ export function parseAttachTo(step) {
 }
 
 /**
+ * Checks if the step should be centered or not. Does not trigger attachTo.element evaluation, making it a pure
+ * alternative for the deprecated step.isCentered() method.
+ * @param resolvedAttachToOptions
+ * @returns {boolean}
+ */
+export function shouldCenterStep(resolvedAttachToOptions) {
+  return !resolvedAttachToOptions.element || !resolvedAttachToOptions.on;
+}
+
+/**
  * Determines options for the tooltip and initializes
  * `step.tooltip` as a Popper instance.
  * @param {Step} step The step instance
@@ -54,12 +69,12 @@ export function setupTooltip(step) {
     step.tooltip.destroy();
   }
 
-  const attachToOptions = parseAttachTo(step);
+  const attachToOptions = step._getResolvedAttachToOptions();
 
   let target = attachToOptions.element;
   const popperOptions = getPopperOptions(attachToOptions, step);
 
-  if (step.isCentered()) {
+  if (shouldCenterStep(attachToOptions)) {
     target = document.body;
     const content = step.shepherdElementComponent.getElement();
     content.classList.add('shepherd-centered');
@@ -116,7 +131,7 @@ export function getPopperOptions(attachToOptions, step) {
     strategy: 'absolute'
   };
 
-  if (step.isCentered()) {
+  if (shouldCenterStep(attachToOptions)) {
     popperOptions = makeCenteredPopper(step);
   } else {
     popperOptions.placement = attachToOptions.on;

--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -13,7 +13,7 @@ declare class Step extends Evented {
    * @return The newly created Step instance
    */
   constructor(tour: Tour, options: Step.StepOptions);//TODO superheri Note: Return on constructor is not possible in typescript. Could this be possible to make this the same for the constructor of the Step class?
-   
+
   /**
    * The string used as the `id` for the step.
    */
@@ -232,7 +232,7 @@ declare namespace Step {
   type PopperPlacement = 'auto'|'auto-start'|'auto-end'|'top'|'top-start'|'top-end'|'bottom'|'bottom-start'|'bottom-end'|'right'|'right-start'|'right-end'|'left'|'left-start'|'left-end';
 
   interface StepOptionsAttachTo {
-    element?: HTMLElement | string;
+    element?: HTMLElement | string | (() => HTMLElement | string | null | undefined);
     on?: PopperPlacement;
   }
 
@@ -259,7 +259,7 @@ declare namespace Step {
      * Extra classes to apply to the `<a>`
      */
     classes?: string;
-    
+
     /**
      * Whether the button should be disabled
      * When the value is `true`, or the function returns `true` the button will be disabled
@@ -270,7 +270,7 @@ declare namespace Step {
      * The aria-label text of the button
      */
     label?: string;
-    
+
     /**
      * A boolean, that when true, adds a `shepherd-button-secondary` class to the button.
      */

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -1,3 +1,4 @@
+import { spy } from 'sinon';
 import { Step } from '../../../src/js/step.js';
 import { getPopperOptions, parseAttachTo } from '../../../src/js/utils/general.js';
 
@@ -22,6 +23,39 @@ describe('General Utils', function() {
 
       const { element } = parseAttachTo(step);
       expect(element).toBeFalsy();
+    });
+
+    it('accepts callback function as element', function() {
+      const callback = spy();
+
+      const step = new Step({}, {
+        attachTo: { element: callback, on: 'center' }
+      });
+
+      parseAttachTo(step);
+      expect(callback.called).toBe(true);
+    });
+
+    it('correctly resolves elements when given function that returns a selector', function() {
+      const step = new Step({}, {
+        attachTo: { element: () => 'body', on: 'center' }
+      });
+
+      const { element } = parseAttachTo(step);
+      expect(element).toBe(document.body);
+    });
+
+    it('binds element callback to step', function() {
+      const step = new Step({}, {
+        attachTo: {
+          element() {
+            expect(this).toBe(step);
+          },
+          on: 'center'
+        }
+      });
+
+      parseAttachTo(step);
     });
   });
 


### PR DESCRIPTION
This PR introduces lazy evaluation of `attachTo.element`,  and memoization of it's result. To do that, it extends `attachTo.element` signature to also accept a function. `attachTo.element` is resolved in the `before-show` phase. A by-product is that string selectors are now also resolved in the same phase, and only once (which is likely, but depends on usage and therefore is not guaranteed - see below for explanation).

New interface of `StepOptionsAttachTo`:

```js
  interface StepOptionsAttachTo {
    element?: HTMLElement | string | (() => HTMLElement | string | null | undefined);
    on?: PopperPlacement;
  }
```

## Benefits:

1. It is now simplier to tour dynamic content - the `attachTo` elements do not have to exist in DOM during tour creation, or even at tour start. The element to attach to is evaluated on demand, during the `before-show` phase, triggered by `Step._show()` method right before setting up step elements.
2. The library gets much more robust - we memoize the resolver result and use that for all logic required to render a step. Previously, if you supplied a selector string to `attachTo.element`, the library would call `document.querySelector` on it approximately 4 times for every `_show`. That's 4 places for potential failures.
3. Step options can now be immutable - previously, if you wanted to have lazy evaluation of `attachTo.element`, you had to use `beforeShowPromise` and modify the options accordingly. With this change, you can use a callback instead.

## Talking points and things to consider:

**1. Should we get rid of `Step.isCentered`?**
`Step.isCentered` is a problematic method. It used to parse `attachTo` options on every call, which isn't good design because we cannot ensure the resolver result will be the same. `attachTo.element` might exist for the initial call, and be gone for another one. What more, it causes trouble in other parts of the library (see 2.), overall making the code uglier. I don't really see the reason for this method to be public, or exist at all - I have created a pure alternative for internal use (`shouldCenterStep`). I left `Step.isCentered` deprecated for now - should we just remove it?
**2. Should `Step._getResolvedAttachToOptions` throw an Error if accessed before `attachTo` evaluation?**
This would be much cleaner, but would prevent `Step._scrollTo` from being called before `_show`, and ideally also require the removal of `Step.isCentered`. Both of these make a lot of sense, `Step.isCentered` is pointless as explained in 1., and `Step._scrollTo` does not need to be called internally before the show phase. This change would make the lazy evaluation logic a lot cleaner. Resolving `attachTo.element` right before a step is rendered makes a lot of sense architecturally, I can't see any other tour lifecycle phase when this would be needed.
**3. This is *potentially* a breaking change.**
Because we memoize the resolver result, this is potentially a breaking change. The reason being that we only invoke `parseAttachTo` once, meaning that for selector strings the corresponding element is only looked for once for every  `Step._show`. Previously, if you supplied a selector string to `attachTo.element`, `parseAttachTo` (and therefore `document.querySelector`) would be called approximately 4 times for every `Step._show`. Of course, this could only become an issue in horribly-written user code, where the programmer toured highly dynamic content, relied on string selectors while doing so, and accepted all the errors being printed in the console, but it's a behaviour change and potential issue nonetheless.
**4. If this qualifies for a major release, maybe we could go for points 1. and 2.?**
It would really make this much more robust, and would only require minor modifications to tests. I would be willing to make those changes.

Super interested to hear your opinion on this. This is an important feature for me, as I'm building a highly-interactive tour of very dynamic content, I would love to see it implemented this way or another. Looking forward to cooperate to see this through.

Related: https://github.com/shipshapecode/shepherd/issues/1177