### PR TITLE
Remove `shepherd-target-click-disabled` class on step hide

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -435,6 +435,7 @@ export class Step extends Evented {
     }
 
     target.classList.remove(
+      'shepherd-target-click-disabled',
       `${this.classPrefix}shepherd-enabled`,
       `${this.classPrefix}shepherd-target`
     );


### PR DESCRIPTION
Hey, this fixes an issue where the `shepherd-target-click-disabled` class is not removed from the highlight target after a step is hidden. While `shepherd-active` and `shepherd-target` classes are correctly removed on step `hide`, the `shepherd-target-click-disabled` is not. `shepherd-target-click-disabled` is only removed when the tour completes.

This problem prevents touring the same element twice, where in one step it's not clickable, and in the other it is. See the repro: https://codesandbox.io/s/practical-ives-9j6u9