### PR TITLE
Add div over the clipped region when modalIsVisible is enabled

### DIFF
--- a/src/js/components/shepherd-modal.svelte
+++ b/src/js/components/shepherd-modal.svelte
@@ -7,8 +7,17 @@
   let modalIsVisible = false;
   let rafId = undefined;
   let pathDefinition;
+  let pathRect;
 
-  $: pathDefinition = makeOverlayPath(openingProperties);
+  $: {
+    pathDefinition = makeOverlayPath(openingProperties);
+    pathRect = {
+      x: openingProperties.x,
+      y: openingProperties.y,
+      width: openingProperties.width,
+      height: openingProperties.height,
+    };
+  }
 
   closeModalOpening();
 
@@ -226,3 +235,8 @@
 >
   <path d="{pathDefinition}"></path>
 </svg>
+<div
+  class="{`${(modalIsVisible ? 'shepherd-modal-is-visible' : '')} shepherd-modal-overlay-clipped-path`}"
+  style="position:absolute;left:{pathRect.x}px;top:{pathRect.y}px;width:{pathRect.width}px;height:{pathRect.height}px"
+>
+</div>


### PR DESCRIPTION
### Reasoning

In `modalIsVisible` mode I would like to be able to apply some custom styling to the highlighted element (e.g. add a ripple effect or change the background color of this region). Currently it's not possible because there is no html element which covers this region.

This PR adds a rectangular element over the clipped region which can be customized with CSS.