### PR TITLE
I faced a problem while was trying to install shepherdjs

### DIFF
--- a/docs-src/tutorials/01-install.md
+++ b/docs-src/tutorials/01-install.md
@@ -28,10 +28,11 @@ to the release in GitHub. You can find those assets [here](https://github.com/sh
 
 ### jsDelivr CDN
 
-You can use jsDelivr to pull down any release from npm. For example, you could include v5.0.1 in your app
+You can use jsDelivr to pull down any release from npm. For example, you could include v8.3.1 with styles in your app
 with:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/shepherd.js@5.0.1/dist/js/shepherd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/shepherd.js@8.3.1/dist/js/shepherd.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/shepherd.js@8.3.1/dist/css/shepherd.css"/>
 ```
 


### PR DESCRIPTION
When I was looking through the documentation, I couldn't find how to get proper shepherd styles along with shepherdjs. I found out that, I can download it from jsdeliver in the beginning of my script. So I suggested, that cdn link for styles should be placed near cdn link for shepherdjs in 01-install.md file