### PR TITLE
Fix type signature for `Evented.off()`

### DIFF
--- a/src/types/evented.d.ts
+++ b/src/types/evented.d.ts
@@ -3,7 +3,7 @@ declare class Evented {
 
   once(event: string, handler: Function): void;
 
-  off(event: string, handler: Function): boolean | void;
+  off(event: string, handler?: Function): boolean | void;
 
   trigger(event: string): void;
 }


### PR DESCRIPTION
Make second parameter, `handler`, optional to reflect implementation.

Fixes #1757 