### PR TITLE
Implement lazy evaluation of attachTo.element

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -166,7 +166,7 @@ created.
   - `Function` to be executed when the step is built. It must return one the two options above.
 - `title`: The step's title. It becomes an `h3` at the top of the step.
 - `attachTo`: The element the step should be attached to on the page. An object with properties `element` and `on`.
-  - `element`: An element selector string or a DOM element.
+  - `element`: An element selector string, a DOM element, or a function (returning a selector, a DOM element, `null` or `undefined`). 
   - `on`: The optional direction to place the Popper tooltip relative to the element.
     - Possible string values: 'auto', 'auto-start', 'auto-end', 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'
 
@@ -177,9 +177,13 @@ const new Step(tour, {
 });
 ```
 
-If you don’t specify an attachTo the element will appear in the middle of the screen.
+If you don’t specify an `attachTo` the element will appear in the middle of the screen. The same will happen if your 
+`attachTo.element` callback returns `null`, `undefined`, or a selector that does not exist in the DOM.
+
 If you omit the `on` portion of `attachTo`, the element will still be highlighted, but the tooltip will appear
 in the middle of the screen, without an arrow pointing to the target.
+
+If the element to highlight does not yet exist while instantiating tour steps, you may use lazy evaluation by supplying a function to `attachTo.element`. The function will be called in the `before-show` phase.
 - `beforeShowPromise`: A function that returns a promise. When the promise resolves, the rest of the `show` code for
 the step will execute. For example:
   ```javascript

--- a/landing/css/welcome.css
+++ b/landing/css/welcome.css
@@ -316,6 +316,11 @@ pre {
 fieldset {
   margin: 0;
   padding: 0;
+} 
+
+button {
+  background-color: transparent;
+  background-image: none;
 }
 
 legend {
@@ -348,6 +353,10 @@ input::-ms-input-placeholder, textarea::-ms-input-placeholder {
   /* 1 */
   color: #9ca3af;
   /* 2 */
+}
+
+input::-ms-input-placeholder, textarea::-ms-input-placeholder {
+  color: #a0aec0;
 }
 
 input::placeholder,
@@ -391,7 +400,7 @@ embed,
 object {
   display: block;
   /* 1 */
-  vertical-align: middle;
+  /* vertical-align: middle; */
   /* 2 */
 }
 
@@ -504,6 +513,14 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .mt-3 {
   margin-top: 0.75rem;
+}
+
+.table {
+  display: table;
+}
+
+.flex-col {
+  flex-direction: column;
 }
 
 .mt-8 {
@@ -722,6 +739,37 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .underline {
   text-decoration-line: underline;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@keyframes pulse {
+  50% {
+    opacity: .5;
+  }
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    animation-timing-function: cubic-bezier(0.8,0,1,1);
+  }
+
+  50% {
+    transform: none;
+    animation-timing-function: cubic-bezier(0,0,0.2,1);
+  }
 }
 
 html, body {
@@ -961,6 +1009,15 @@ pre {
 .hover\:text-navy-light:hover {
   --tw-text-opacity: 1;
   color: rgb(149 159 172 / var(--tw-text-opacity));
+}
+
+@media (min-width: 640px) {
+}
+
+@media (min-width: 768px) {
+  .md\:justify-between {
+    justify-content: space-between;
+  }
 }
 
 @media (min-width: 768px) {

--- a/landing/css/welcome.css
+++ b/landing/css/welcome.css
@@ -316,11 +316,6 @@ pre {
 fieldset {
   margin: 0;
   padding: 0;
-} 
-
-button {
-  background-color: transparent;
-  background-image: none;
 }
 
 legend {
@@ -353,10 +348,6 @@ input::-ms-input-placeholder, textarea::-ms-input-placeholder {
   /* 1 */
   color: #9ca3af;
   /* 2 */
-}
-
-input::-ms-input-placeholder, textarea::-ms-input-placeholder {
-  color: #a0aec0;
 }
 
 input::placeholder,
@@ -400,7 +391,7 @@ embed,
 object {
   display: block;
   /* 1 */
-  /* vertical-align: middle; */
+  vertical-align: middle;
   /* 2 */
 }
 
@@ -513,14 +504,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .mt-3 {
   margin-top: 0.75rem;
-}
-
-.table {
-  display: table;
-}
-
-.flex-col {
-  flex-direction: column;
 }
 
 .mt-8 {
@@ -739,37 +722,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .underline {
   text-decoration-line: underline;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes ping {
-  75%, 100% {
-    transform: scale(2);
-    opacity: 0;
-  }
-}
-
-@keyframes pulse {
-  50% {
-    opacity: .5;
-  }
-}
-
-@keyframes bounce {
-  0%, 100% {
-    transform: translateY(-25%);
-    animation-timing-function: cubic-bezier(0.8,0,1,1);
-  }
-
-  50% {
-    transform: none;
-    animation-timing-function: cubic-bezier(0,0,0.2,1);
-  }
 }
 
 html, body {
@@ -1009,15 +961,6 @@ pre {
 .hover\:text-navy-light:hover {
   --tw-text-opacity: 1;
   color: rgb(149 159 172 / var(--tw-text-opacity));
-}
-
-@media (min-width: 640px) {
-}
-
-@media (min-width: 768px) {
-  .md\:justify-between {
-    justify-content: space-between;
-  }
 }
 
 @media (min-width: 768px) {

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -43,6 +43,7 @@ export class Step extends Evented {
    * If you don’t specify an `attachTo` the element will appear in the middle of the screen. The same will happen if your `attachTo.element` callback returns `null`, `undefined`, or a selector that does not exist in the DOM.
    * If you omit the `on` portion of `attachTo`, the element will still be highlighted, but the tooltip will appear
    * in the middle of the screen, without an arrow pointing to the target.
+   * If the element to highlight does not yet exist while instantiating tour steps, you may use lazy evaluation by supplying a function to `attachTo.element`. The function will be called in the `before-show` phase.
    * @param {string|HTMLElement|function} options.attachTo.element An element selector string, DOM element, or a function (returning a selector, a DOM element, `null` or `undefined`).
    * @param {string} options.attachTo.on The optional direction to place the Popper tooltip relative to the element.
    *   - Possible string values: 'auto', 'auto-start', 'auto-end', 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -40,7 +40,7 @@ export class Step extends Evented {
    * });
    * ```
    *
-   * If you don’t specify an attachTo the element will appear in the middle of the screen.
+   * If you don’t specify an `attachTo` the element will appear in the middle of the screen. The same will happen if your `attachTo.element` callback returns `null`, `undefined`, or a selector that does not exist in the DOM.
    * If you omit the `on` portion of `attachTo`, the element will still be highlighted, but the tooltip will appear
    * in the middle of the screen, without an arrow pointing to the target.
    * @param {string|HTMLElement|function} options.attachTo.element An element selector string, DOM element, or a function (returning a selector, a DOM element, `null` or `undefined`).

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -222,19 +222,6 @@ export class Step extends Evented {
   }
 
   /**
-   * Checks if the step should be centered or not
-   * @return {boolean} True if the step is centered
-   * @deprecated This method causes issues with lazy attachTo evaluation. We evaluate attachTo.element in `before-show`
-   * phase, and then memoize the result to make sure we're always referencing the same element. If you use this before
-   * showing the step, the resulting element might be different, depending on how you configure `attachTo.element`. For
-   * internal code, use shouldCenterStep instead.
-   */
-  isCentered() {
-    const attachToOptions = this._getResolvedAttachToOptions();
-    return !attachToOptions.element || !attachToOptions.on;
-  } 
-
-  /**
    * Check if the step is open and visible
    * @return {boolean} True if the step is open and visible
    */

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -120,6 +120,14 @@ export class Step extends Evented {
       : '';
     this.styles = tour.styles;
 
+    /**
+     * Resolved attachTo options. Due to lazy evaluation, we only resolve the options during `before-show` phase.
+     * Do not use this directly, use the _getResolvedAttachToOptions method instead.
+     * @type {null|{}|{element, to}}
+     * @private
+     */
+    this._resolvedAttachTo = null;
+
     autoBind(this);
 
     this._setOptions(options);
@@ -191,11 +199,38 @@ export class Step extends Evented {
   }
 
   /**
+   * Resolves attachTo options.
+   * @returns {{}|{element, on}}
+   * @private
+   */
+  _resolveAttachToOptions() {
+    this._resolvedAttachTo = parseAttachTo(this);
+    return this._resolvedAttachTo;
+  }
+
+  /**
+   * A selector for resolved attachTo options.
+   * @returns {{}|{element, on}}
+   * @private
+   */
+  _getResolvedAttachToOptions() {
+    if (this._resolvedAttachTo === null) {
+      return this._resolveAttachToOptions();
+    }
+
+    return this._resolvedAttachTo;
+  }
+
+  /**
    * Checks if the step should be centered or not
    * @return {boolean} True if the step is centered
+   * @deprecated This method causes issues with lazy attachTo evaluation. We evaluate attachTo.element in `before-show`
+   * phase, and then memoize the result to make sure we're always referencing the same element. If you use this before
+   * showing the step, the resulting element might be different, depending on how you configure `attachTo.element`. For
+   * internal code, use shouldCenterStep instead.
    */
   isCentered() {
-    const attachToOptions = parseAttachTo(this);
+    const attachToOptions = this._getResolvedAttachToOptions();
     return !attachToOptions.element || !attachToOptions.on;
   }
 
@@ -283,7 +318,7 @@ export class Step extends Evented {
    * @private
    */
   _scrollTo(scrollToOptions) {
-    const { element } = parseAttachTo(this);
+    const { element } = this._getResolvedAttachToOptions();
 
     if (isFunction(this.options.scrollToHandler)) {
       this.options.scrollToHandler(element);
@@ -376,6 +411,8 @@ export class Step extends Evented {
   _show() {
     this.trigger('before-show');
 
+    // Force resolve to make sure the options are updated on subsequent shows.
+    this._resolveAttachToOptions();
     this._setupElements();
 
     if (!this.tour.modal) {

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -43,7 +43,7 @@ export class Step extends Evented {
    * If you don’t specify an attachTo the element will appear in the middle of the screen.
    * If you omit the `on` portion of `attachTo`, the element will still be highlighted, but the tooltip will appear
    * in the middle of the screen, without an arrow pointing to the target.
-   * @param {HTMLElement|string} options.attachTo.element An element selector string or a DOM element.
+   * @param {string|HTMLElement|function} options.attachTo.element An element selector string, DOM element, or a function (returning a selector, a DOM element, `null` or `undefined`).
    * @param {string} options.attachTo.on The optional direction to place the Popper tooltip relative to the element.
    *   - Possible string values: 'auto', 'auto-start', 'auto-end', 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'
    * @param {Object} options.advanceOn An action on the page which should advance shepherd to the next step.

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -232,7 +232,7 @@ export class Step extends Evented {
   isCentered() {
     const attachToOptions = this._getResolvedAttachToOptions();
     return !attachToOptions.element || !attachToOptions.on;
-  }
+  } 
 
   /**
    * Check if the step is open and visible

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -1,5 +1,5 @@
 import { createPopper } from '@popperjs/core';
-import { isString } from './type-check';
+import { isFunction, isString } from './type-check';
 import { makeCenteredPopper } from './popper-options';
 
 /**
@@ -16,9 +16,9 @@ export function normalizePrefix(prefix) {
 }
 
 /**
- * Checks if options.attachTo.element is a string, and if so, tries to find the element
+ * Resolves attachTo options, converting element option value to a qualified HTMLElement.
  * @param {Step} step The step instance
- * @returns {{element, on}}
+ * @returns {{}|{element, on}}
  * `element` is a qualified HTML Element
  * `on` is a string position value
  */
@@ -26,11 +26,16 @@ export function parseAttachTo(step) {
   const options = step.options.attachTo || {};
   const returnOpts = Object.assign({}, options);
 
-  if (isString(options.element)) {
+  if (isFunction(returnOpts.element)) {
+    // Bind the callback to step so that it has access to the object, to enable running additional logic
+    returnOpts.element = returnOpts.element.call(step);
+  }
+
+  if (isString(returnOpts.element)) {
     // Can't override the element in user opts reference because we can't
     // guarantee that the element will exist in the future.
     try {
-      returnOpts.element = document.querySelector(options.element);
+      returnOpts.element = document.querySelector(returnOpts.element);
     } catch (e) {
       // TODO
     }
@@ -45,6 +50,16 @@ export function parseAttachTo(step) {
 }
 
 /**
+ * Checks if the step should be centered or not. Does not trigger attachTo.element evaluation, making it a pure
+ * alternative for the deprecated step.isCentered() method.
+ * @param resolvedAttachToOptions
+ * @returns {boolean}
+ */
+export function shouldCenterStep(resolvedAttachToOptions) {
+  return !resolvedAttachToOptions.element || !resolvedAttachToOptions.on;
+}
+
+/**
  * Determines options for the tooltip and initializes
  * `step.tooltip` as a Popper instance.
  * @param {Step} step The step instance
@@ -54,12 +69,12 @@ export function setupTooltip(step) {
     step.tooltip.destroy();
   }
 
-  const attachToOptions = parseAttachTo(step);
+  const attachToOptions = step._getResolvedAttachToOptions();
 
   let target = attachToOptions.element;
   const popperOptions = getPopperOptions(attachToOptions, step);
 
-  if (step.isCentered()) {
+  if (shouldCenterStep(attachToOptions)) {
     target = document.body;
     const content = step.shepherdElementComponent.getElement();
     content.classList.add('shepherd-centered');
@@ -117,7 +132,7 @@ export function getPopperOptions(attachToOptions, step) {
     strategy: 'absolute'
   };
 
-  if (step.isCentered()) {
+  if (shouldCenterStep(attachToOptions)) {
     popperOptions = makeCenteredPopper(step);
   } else {
     popperOptions.placement = attachToOptions.on;

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -56,6 +56,10 @@ export function parseAttachTo(step) {
  * @returns {boolean}
  */
 export function shouldCenterStep(resolvedAttachToOptions) {
+  if (resolvedAttachToOptions === undefined || resolvedAttachToOptions === null) {
+    return true
+  }
+  
   return !resolvedAttachToOptions.element || !resolvedAttachToOptions.on;
 }
 

--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -13,7 +13,7 @@ declare class Step extends Evented {
    * @return The newly created Step instance
    */
   constructor(tour: Tour, options: Step.StepOptions);//TODO superheri Note: Return on constructor is not possible in typescript. Could this be possible to make this the same for the constructor of the Step class?
-   
+
   /**
    * The string used as the `id` for the step.
    */
@@ -232,7 +232,7 @@ declare namespace Step {
   type PopperPlacement = 'auto'|'auto-start'|'auto-end'|'top'|'top-start'|'top-end'|'bottom'|'bottom-start'|'bottom-end'|'right'|'right-start'|'right-end'|'left'|'left-start'|'left-end';
 
   interface StepOptionsAttachTo {
-    element?: HTMLElement | string;
+    element?: HTMLElement | string | (() => HTMLElement | string | null | undefined);
     on?: PopperPlacement;
   }
 
@@ -259,7 +259,7 @@ declare namespace Step {
      * Extra classes to apply to the `<a>`
      */
     classes?: string;
-    
+
     /**
      * Whether the button should be disabled
      * When the value is `true`, or the function returns `true` the button will be disabled

--- a/test/cypress/integration/test.acceptance.js
+++ b/test/cypress/integration/test.acceptance.js
@@ -263,38 +263,38 @@ describe('Shepherd Acceptance Tests', () => {
           
           tour.start();
 
-          cy.wait(250);
-          
-          tour.next();
           const dummyTarget = document.createElement('div');
           dummyTarget.setAttribute('id', 'dummyTarget')
           document.querySelector('[data-test-hero-including]').appendChild(dummyTarget);
           
-          // Check dummy step binding
-          cy.get('[data-shepherd-step-id="dummyStep"] .shepherd-text')
-          .contains('Dummy step').should('be.visible');
-          assert.deepEqual(
-            document.querySelector('#dummyTarget'),
-            tour.getCurrentStep().target,
-            '#dummyTarget is the target'
-            );
-            
-          tour.next();
-          const lazyTarget = document.createElement('div');
-          lazyTarget.setAttribute('id', 'lazyTarget');
-          // Append to the hero so that the element is in viewport when running the test
-          document.querySelector('[data-test-hero-including]').appendChild(lazyTarget);
+          tour.next()
           
-          // Check on binding of current lazy step
-          cy.get('[data-shepherd-step-id="lazyStep"] .shepherd-text')
-          .contains('Lazy target evaluation works too!').should('be.visible');
-          assert.deepEqual(
-            document.querySelector('#lazyTarget'),
-            tour.getCurrentStep().target,
-            '#lazyTarget is the target'
-          )
+          cy.get('[data-shepherd-step-id="dummyStep"] .shepherd-text').then((dummyJq) => {
+            // dummyJq.contains('Dummy step').should('be.visible');
+            assert.deepEqual(
+              document.querySelector('#dummyTarget'),
+              tour.getCurrentStep().target,
+              '#dummyTarget is the target'
+              );
+          })
+
+          //// SECOND ASSERTION
+
+          // const lazyTarget = document.createElement('div');
+          // lazyTarget.setAttribute('id', 'lazyTarget');
+          // document.querySelector('[data-test-hero-including]').appendChild(lazyTarget);
+
+          // tour.next();
+          
+          // cy.get('[data-shepherd-step-id="lazyStep"] .shepherd-text', {includeShadowDom: true})
+          // .contains('Lazy target evaluation works too!').should('be.visible');
+          // assert.deepEqual(
+          //   document.querySelector('#lazyTarget'),
+          //   tour.getCurrentStep().target,
+          //   '#lazyTarget is the target'
+          // )
             
-          tour.removeStep('dummyStep');
+          // tour.removeStep('dummyStep');
 
           // Check binding of previous (now deleted) dummy step
           // cy.get('[data-shepherd-step-id="dummyStep"] .shepherd-text')

--- a/test/cypress/integration/test.acceptance.js
+++ b/test/cypress/integration/test.acceptance.js
@@ -234,23 +234,23 @@ describe('Shepherd Acceptance Tests', () => {
           const steps = () => {
             return [
               {
-                text: 'First step'
+                text: 'foo'
               },
               {
-                text: 'Dummy step',
+                text: 'bar',
                 attachTo: {
-                  element: () => document.querySelector('#dummyTarget'),
-                  on: 'top'
-                },
-                id: 'dummyStep'
-              },
-              {
-                text: 'Lazy target evaluation works too!',
-                attachTo: {
-                  element: () => document.querySelector('#lazyTarget'), // this element does not yet exist
+                  element: () => document.querySelector('#bar'),
                   on: 'bottom'
                 },
-                id: 'lazyStep'
+                id: 'bar'
+              },
+              {
+                text: 'baz',
+                attachTo: {
+                  element: () => document.querySelector('#baz'),
+                  on: 'bottom'
+                },
+                id: 'baz'
               }
             ];
           };
@@ -262,48 +262,54 @@ describe('Shepherd Acceptance Tests', () => {
           }, steps);
           
           tour.start();
-
-          const dummyTarget = document.createElement('div');
-          dummyTarget.setAttribute('id', 'dummyTarget')
-          document.querySelector('[data-test-hero-including]').appendChild(dummyTarget);
           
+          const barTarget = document.createElement('div');
+          barTarget.setAttribute('id', 'bar')
+          document.querySelector('[data-test-hero-including]').appendChild(barTarget);
+
+          const bazTarget = document.createElement('div');
+          bazTarget.setAttribute('id', 'baz');
+          document.querySelector('[data-test-hero-including]').appendChild(bazTarget);
+
           tour.next()
           
-          cy.get('[data-shepherd-step-id="dummyStep"] .shepherd-text').then((dummyJq) => {
-            // dummyJq.contains('Dummy step').should('be.visible');
-            assert.deepEqual(
-              document.querySelector('#dummyTarget'),
-              tour.getCurrentStep().target,
-              '#dummyTarget is the target'
+          cy.get('[data-shepherd-step-id="bar"] .shepherd-text')
+            .then(() => {
+              cy.get('[data-shepherd-step-id="bar"] .shepherd-text').contains('bar').should('be.visible');
+              assert.deepEqual(
+                document.querySelector('#bar'),
+                tour.getCurrentStep().target,
+                '#bar is the target'
               );
-          })
-
-          //// SECOND ASSERTION
-
-          // const lazyTarget = document.createElement('div');
-          // lazyTarget.setAttribute('id', 'lazyTarget');
-          // document.querySelector('[data-test-hero-including]').appendChild(lazyTarget);
-
-          // tour.next();
+            })
+            .then(() => {
+              tour.next()
+            })
           
-          // cy.get('[data-shepherd-step-id="lazyStep"] .shepherd-text', {includeShadowDom: true})
-          // .contains('Lazy target evaluation works too!').should('be.visible');
-          // assert.deepEqual(
-          //   document.querySelector('#lazyTarget'),
-          //   tour.getCurrentStep().target,
-          //   '#lazyTarget is the target'
-          // )
-            
-          // tour.removeStep('dummyStep');
+          cy.get('[data-shepherd-step-id="baz"] .shepherd-text')
+            .then(() => {
+              cy.get('[data-shepherd-step-id="baz"] .shepherd-text').contains('baz').should('be.visible');
+              assert.deepEqual(
+                document.querySelector('#baz'),
+                tour.getCurrentStep().target,
+                '#baz is the target'
+              )
+            })
+            .then(() => {
+              tour.removeStep('bar')
+            })
+            .then(() => {
+              // Check binding of previous (now deleted) dummy step
+              // cy.get('[data-shepherd-step-id="dummyStep"] .shepherd-text')
+              // .contains('Dummy step').should('be.visible');
+              // assert.deepEqual(
+              //   document.querySelector('#dummyTarget'),
+              //   tour.getCurrentStep().target,
+              //   '#lazyTarget is the target'
+              // );
 
-          // Check binding of previous (now deleted) dummy step
-          // cy.get('[data-shepherd-step-id="dummyStep"] .shepherd-text')
-          // .contains('Dummy step').should('be.visible');
-          // assert.deepEqual(
-          //   document.querySelector('#dummyTarget'),
-          //   tour.getCurrentStep().target,
-          //   '#lazyTarget is the target'
-          // );
+            })
+            
            
           // cy.document().then(() => {
           //   assert.deepEqual(undefined, tour.getCurrentStep().target, 'target is undefined');

--- a/test/cypress/integration/test.acceptance.js
+++ b/test/cypress/integration/test.acceptance.js
@@ -1,6 +1,5 @@
 import setupTour from '../utils/setup-tour';
 import { assert } from 'chai';
-import { doc } from 'prettier';
 
 let Shepherd;
 

--- a/test/cypress/integration/test.acceptance.js
+++ b/test/cypress/integration/test.acceptance.js
@@ -277,7 +277,6 @@ describe('Shepherd Acceptance Tests', () => {
           quxTarget.setAttribute('class', 'baz');
           quxTarget.setAttribute('id', 'qux');
           document.querySelector('[data-test-hero-including]').appendChild(quxTarget);
-          debugger
 
           tour.next()
           

--- a/test/cypress/integration/test.acceptance.js
+++ b/test/cypress/integration/test.acceptance.js
@@ -1,5 +1,6 @@
 import setupTour from '../utils/setup-tour';
 import { assert } from 'chai';
+import { doc } from 'prettier';
 
 let Shepherd;
 
@@ -247,7 +248,7 @@ describe('Shepherd Acceptance Tests', () => {
               {
                 text: 'baz',
                 attachTo: {
-                  element: () => document.querySelector('#baz'),
+                  element: () => document.querySelector('.baz'),
                   on: 'bottom'
                 },
                 id: 'baz'
@@ -262,14 +263,22 @@ describe('Shepherd Acceptance Tests', () => {
           }, steps);
           
           tour.start();
+
           
           const barTarget = document.createElement('div');
           barTarget.setAttribute('id', 'bar')
           document.querySelector('[data-test-hero-including]').appendChild(barTarget);
 
           const bazTarget = document.createElement('div');
+          bazTarget.setAttribute('class', 'baz');
           bazTarget.setAttribute('id', 'baz');
           document.querySelector('[data-test-hero-including]').appendChild(bazTarget);
+
+          const quxTarget = document.createElement('div');
+          quxTarget.setAttribute('class', 'baz');
+          quxTarget.setAttribute('id', 'qux');
+          document.querySelector('[data-test-hero-including]').appendChild(quxTarget);
+          debugger
 
           tour.next()
           
@@ -296,24 +305,17 @@ describe('Shepherd Acceptance Tests', () => {
               )
             })
             .then(() => {
-              tour.removeStep('bar')
+              bazTarget.remove()
             })
             .then(() => {
-              // Check binding of previous (now deleted) dummy step
-              // cy.get('[data-shepherd-step-id="dummyStep"] .shepherd-text')
-              // .contains('Dummy step').should('be.visible');
-              // assert.deepEqual(
-              //   document.querySelector('#dummyTarget'),
-              //   tour.getCurrentStep().target,
-              //   '#lazyTarget is the target'
-              // );
-
+              cy.get('[data-shepherd-step-id="baz"] .shepherd-text').contains('baz').should('be.visible');
+              cy.get('.shepherd-element').should('have.focus');
+              assert.deepEqual(
+                tour.getCurrentStep()._getResolvedAttachToOptions().on,
+                'bottom',
+                'Resolved attachTo on is maintained'
+              )
             })
-            
-           
-          // cy.document().then(() => {
-          //   assert.deepEqual(undefined, tour.getCurrentStep().target, 'target is undefined');
-          // });
         });
       });
 

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -474,7 +474,6 @@ describe('Tour | Step', () => {
       const resTester = document.createElement('div');
       let resHandlerCalled = false;
       resTester.classList.add('post-res-scroll-test');
-      const scrollIntoViewSpy = spy(resTester.scrollIntoView)
       document.body.appendChild(resTester);
 
       const beforeShowPromise = new Promise((resolve) => {
@@ -487,12 +486,14 @@ describe('Tour | Step', () => {
           return beforeShowPromise
         }
       });
-      
+
       resTester.scrollIntoView = () => (resHandlerCalled = true);
+
+      const scrollIntoViewSpy = spy(resTester.scrollIntoView)
 
       step.show()
 
-      step._scrollTo();
+      step._scrollTo(true);
       
       expect(resHandlerCalled).toBeTruthy();
       expect(scrollIntoViewSpy.called).toBeTruthy();

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -579,7 +579,24 @@ describe('Tour | Step', () => {
 
   describe('.isCentered()', () => {
     // Where is isCentered being used in the package? Cannot see it being used as a dependency anywhere
-    it('Can bind with a defined attachTo', () => {
+    it('Returns false when either element or on options of attachTo are given initial values', () => {
+      const step1Spy = spy();
+  
+      const instance = new Shepherd.Tour({
+        steps: [
+          {
+            text: 'step 1',
+            attachTo: { element: step1Spy, on: 'left' }
+          }
+        ]
+      });
+  
+      instance.start()
+  
+      expect(instance.getCurrentStep().isCentered()).toBe(false)
+    })
+
+    it('RESOLVED: Returns false when either element or on options of attachTo are given initial values)', () => {
       const step1Spy = spy();
   
       const instance = new Shepherd.Tour({
@@ -592,11 +609,11 @@ describe('Tour | Step', () => {
       });
   
       instance.start()
-  
-      expect(instance.steps[0].isCentered()).toBe(true)
+      // instance.getCurrentStep().show()
+      expect(instance.getCurrentStep().isCentered()).toBe(true)
     })
 
-    it('Can bind with a falsy attachTo', () => {
+    it('Returns true when both attachTo options (element and on) are not given initial values', () => {
       const instance = new Shepherd.Tour({
         steps: [
           {
@@ -607,7 +624,7 @@ describe('Tour | Step', () => {
   
       instance.start()
 
-      expect(instance.steps[0].isCentered()).toBe(true)
+      expect(instance.getCurrentStep().isCentered()).toBe(true)
     })
   })
 

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -724,6 +724,11 @@ describe('Tour | Step', () => {
     });
 
     it('can evaluate _getResolvedAttachToOptions before step before-show phase', () => {
+      const step2AttachTo = {
+        element: () => {},
+        on: 'auto'
+      }
+
       const instance = new Shepherd.Tour({
         steps: [
           {
@@ -732,15 +737,14 @@ describe('Tour | Step', () => {
           },
           {
             text: 'step 2',
-            attachTo: { element: () => {}, on: 'auto' }
+            attachTo: step2AttachTo
           }
         ]
       });
 
       instance.start()
 
-      expect(instance.steps[1]._getResolvedAttachToOptions).toBeTruthy()
-      
+      expect(instance.steps[1]._getResolvedAttachToOptions()).toBe(step2AttachTo)
     })
   });
 });

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -2,6 +2,7 @@ import { spy } from 'sinon';
 import Shepherd from '../../src/js/shepherd';
 import { Step } from '../../src/js/step';
 import { Tour } from '../../src/js/tour';
+import { parseAttachTo } from '../../src/js/utils/general'
 
 // since importing non UMD, needs assignment
 window.Shepherd = Shepherd;
@@ -467,6 +468,35 @@ describe('Tour | Step', () => {
 
       step._scrollTo();
       expect(handlerAdded).toBeTruthy();
+    });
+
+    it('calls scroll native method after before-show promise resolution', () => {
+      const resTester = document.createElement('div');
+      let resHandlerCalled = false;
+      resTester.classList.add('post-res-scroll-test');
+      document.body.appendChild(resTester);
+      const step = new Step('test', {
+        attachTo: { element: '.post-res-scroll-test', on: 'center' }
+      });
+      
+      parseAttachTo(step)
+
+      resTester.scrollIntoView = () => (resHandlerCalled = true);
+
+      step._scrollTo();
+      expect(resHandlerCalled).toBeTruthy();
+    })
+
+    it('calls the custom handler after before-show promise resolution', () => {
+      let resHandlerAdded = false;
+      const step = new Step('test', {
+        scrollToHandler: () => (resHandlerAdded = true)
+      });
+
+      parseAttachTo(step)
+
+      step._scrollTo();
+      expect(resHandlerAdded).toBeTruthy();
     });
   });
 

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -474,28 +474,44 @@ describe('Tour | Step', () => {
       const resTester = document.createElement('div');
       let resHandlerCalled = false;
       resTester.classList.add('post-res-scroll-test');
+      const scrollIntoViewSpy = spy(resTester.scrollIntoView)
       document.body.appendChild(resTester);
+
+      const beforeShowPromise = new Promise((resolve) => {
+        return setTimeout(1000, resolve('beforeShowPromise worked!'));
+      });
+
       const step = new Step('test', {
-        attachTo: { element: '.post-res-scroll-test', on: 'center' }
+        attachTo: { element: '.post-res-scroll-test', on: 'center' },
+        beforeShowPromise: () => {
+          return beforeShowPromise
+        }
       });
       
-      parseAttachTo(step)
-
       resTester.scrollIntoView = () => (resHandlerCalled = true);
 
-      step._scrollTo();
+      step.show()
+      
       expect(resHandlerCalled).toBeTruthy();
+      expect(scrollIntoViewSpy.called).toBeTruthy();
     })
 
     it('calls the custom handler after before-show promise resolution', () => {
       let resHandlerAdded = false;
-      const step = new Step('test', {
-        scrollToHandler: () => (resHandlerAdded = true)
+
+      const beforeShowPromise = new Promise((resolve) => {
+        return setTimeout(1000, resolve('beforeShowPromise worked!'));
       });
 
-      parseAttachTo(step)
+      const step = new Step('test', {
+        scrollToHandler: () => (resHandlerAdded = true),
+        beforeShowPromise: () => {
+          return beforeShowPromise
+        }
+      });
 
-      step._scrollTo();
+      step.show();
+
       expect(resHandlerAdded).toBeTruthy();
     });
 

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -731,7 +731,7 @@ describe('Tour | Step', () => {
       // expect(result1).toBe(result2);
     });
 
-    it('can evaluate _getResolvedAttachToOptions before step before-show phase', async () => {
+    it('can evaluate _getResolvedAttachToOptions before step before-show phase', () => {
       const instance = new Shepherd.Tour({
         steps: [
           {
@@ -748,7 +748,7 @@ describe('Tour | Step', () => {
 
       instance.start()
 
-      await expect(instance.getById('step2')._getResolvedAttachToOptions()).toBe({ element: undefined, on: 'auto'})
+      expect(instance.getById('step2')._getResolvedAttachToOptions()).toEqual({ element: undefined, on: 'auto'})
     })
   });
 });

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -491,6 +491,8 @@ describe('Tour | Step', () => {
       resTester.scrollIntoView = () => (resHandlerCalled = true);
 
       step.show()
+
+      step._scrollTo();
       
       expect(resHandlerCalled).toBeTruthy();
       expect(scrollIntoViewSpy.called).toBeTruthy();
@@ -511,6 +513,8 @@ describe('Tour | Step', () => {
       });
 
       step.show();
+
+      step._scrollTo();
 
       expect(resHandlerAdded).toBeTruthy();
     });

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -488,19 +488,12 @@ describe('Tour | Step', () => {
         }
       });
 
-      // const scrollIntoViewSpy = spy(resTester.scrollIntoView)
-      
       step.show()
 
       step._scrollTo();
 
-      // try {
-        expect(resHandlerCalled).toBeTruthy();
-        expect(resSpy).toBeCalled();
-      //   done()
-      // } catch (err) {
-      //   done(error)
-      // }
+      expect(resHandlerCalled).toBeTruthy();
+      expect(resSpy).toBeCalled();
     })
     
     it('calls the custom handler after before-show promise resolution', () => {
@@ -517,11 +510,14 @@ describe('Tour | Step', () => {
         }
       });
 
-      // step.show();
+      const resSpy = jest.spyOn(step, 'scrollToHandler')
+
+      step.show();
 
       step._scrollTo();
 
       expect(resHandlerAdded).toBeTruthy();
+      expect(resSpy).toBeCalled();
     });
   });
 

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -491,12 +491,12 @@ describe('Tour | Step', () => {
 
       const scrollIntoViewSpy = spy(resTester.scrollIntoView)
 
-      step.show()
+      step.show();
 
-      step._scrollTo(true);
-      
-      expect(resHandlerCalled).toBeTruthy();
-      expect(scrollIntoViewSpy.called).toBeTruthy();
+      step._scrollTo(true).then(() => {
+        expect(resHandlerCalled).toBeTruthy();
+        expect(scrollIntoViewSpy.called).toBeTruthy();
+      });
     })
 
     it('calls the custom handler after before-show promise resolution', () => {

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -719,16 +719,17 @@ describe('Tour | Step', () => {
 
       instance.start();
 
-      // expect(instance.getCurrentStep().isOpen()).toBe(true);
-      // // Subsequent calls to the getter return the same object
-      // const result1 = instance.getCurrentStep()._getResolvedAttachToOptions();
+      expect(instance.getCurrentStep().isOpen()).toBe(true);
+      // Subsequent calls to the getter return the same object
+      const result1 = instance.getCurrentStep()._getResolvedAttachToOptions();
 
-      // expect(result1).not.toBeNull()
+      expect(result1).not.toBeNull()
 
-      // instance.next();
+      instance.next();
       
-      // const result2 = instance.getById('step1')
-      // expect(result1).toBe(result2);
+      const result2 = instance.getById('step1')._getResolvedAttachToOptions();
+      
+      expect(result1).toEqual(result2);
     });
 
     it('can evaluate _getResolvedAttachToOptions before step before-show phase', () => {

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -2,7 +2,6 @@ import { spy } from 'sinon';
 import Shepherd from '../../src/js/shepherd';
 import { Step } from '../../src/js/step';
 import { Tour } from '../../src/js/tour';
-import { parseAttachTo } from '../../src/js/utils/general'
 
 // since importing non UMD, needs assignment
 window.Shepherd = Shepherd;
@@ -470,11 +469,12 @@ describe('Tour | Step', () => {
       expect(handlerAdded).toBeTruthy();
     });
 
-    it('calls scroll native method after before-show promise resolution', async () => {
+    it('calls scroll native method after before-show promise resolution', () => {
       const resTester = document.createElement('div');
       let resHandlerCalled = false;
       resTester.classList.add('post-res-scroll-test');
       resTester.scrollIntoView = () => (resHandlerCalled = true);
+      const resSpy = jest.spyOn(resTester, 'scrollIntoView')
       document.body.appendChild(resTester);
 
       const beforeShowPromise = new Promise((resolve) => {
@@ -488,15 +488,19 @@ describe('Tour | Step', () => {
         }
       });
 
-      const scrollIntoViewSpy = spy(resTester.scrollIntoView)
+      // const scrollIntoViewSpy = spy(resTester.scrollIntoView)
       
-      await step.beforeShowPromise();
+      step.show()
 
       step._scrollTo();
-      
-      expect(resHandlerCalled).toBeTruthy();
-      
-      await expect(scrollIntoViewSpy.called).toBeTruthy();
+
+      // try {
+        expect(resHandlerCalled).toBeTruthy();
+        expect(resSpy).toBeCalled();
+      //   done()
+      // } catch (err) {
+      //   done(error)
+      // }
     })
     
     it('calls the custom handler after before-show promise resolution', () => {
@@ -513,7 +517,7 @@ describe('Tour | Step', () => {
         }
       });
 
-      step.show();
+      // step.show();
 
       step._scrollTo();
 

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -490,11 +490,12 @@ describe('Tour | Step', () => {
 
       const scrollIntoViewSpy = spy(resTester.scrollIntoView)
       
-      step.show();
+      await step.beforeShowPromise();
 
-      step._scrollTo(true);
+      step._scrollTo();
       
-      await expect(resHandlerCalled).toBeTruthy();
+      expect(resHandlerCalled).toBeTruthy();
+      
       await expect(scrollIntoViewSpy.called).toBeTruthy();
     })
     

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -724,6 +724,7 @@ describe('Tour | Step', () => {
       const result1 = instance.getCurrentStep()._getResolvedAttachToOptions();
       expect(result1).not.toBeNull().then(() => {
         instance.next();
+        const result2 = instance.getById('step1')
         expect(result1).toBe(result2);
       });
     });

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -474,6 +474,7 @@ describe('Tour | Step', () => {
       const resTester = document.createElement('div');
       let resHandlerCalled = false;
       resTester.classList.add('post-res-scroll-test');
+      resTester.scrollIntoView = () => (resHandlerCalled = true);
       document.body.appendChild(resTester);
 
       const beforeShowPromise = new Promise((resolve) => {
@@ -487,18 +488,16 @@ describe('Tour | Step', () => {
         }
       });
 
-      resTester.scrollIntoView = () => (resHandlerCalled = true);
-
       const scrollIntoViewSpy = spy(resTester.scrollIntoView)
-
+      
       step.show();
 
-      step._scrollTo(true).then(() => {
+      step._scrollTo(true).then((ghost) => {
         expect(resHandlerCalled).toBeTruthy();
         expect(scrollIntoViewSpy.called).toBeTruthy();
       });
     })
-
+    
     it('calls the custom handler after before-show promise resolution', () => {
       let resHandlerAdded = false;
 

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -470,7 +470,7 @@ describe('Tour | Step', () => {
       expect(handlerAdded).toBeTruthy();
     });
 
-    it('calls scroll native method after before-show promise resolution', () => {
+    it('calls scroll native method after before-show promise resolution', async () => {
       const resTester = document.createElement('div');
       let resHandlerCalled = false;
       resTester.classList.add('post-res-scroll-test');
@@ -492,10 +492,10 @@ describe('Tour | Step', () => {
       
       step.show();
 
-      step._scrollTo(true).then((ghost) => {
-        expect(resHandlerCalled).toBeTruthy();
-        expect(scrollIntoViewSpy.called).toBeTruthy();
-      });
+      step._scrollTo(true);
+      
+      await expect(resHandlerCalled).toBeTruthy();
+      await expect(scrollIntoViewSpy.called).toBeTruthy();
     })
     
     it('calls the custom handler after before-show promise resolution', () => {

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -709,7 +709,8 @@ describe('Tour | Step', () => {
       const instance = new Shepherd.Tour({
         steps: [{
           text: 'step 1',
-          attachTo: { element: () => {}, on: 'auto' }
+          attachTo: { element: () => {}, on: 'auto' },
+          id: 'step1'
         }, {
           text: 'step 2',
           attachTo: { element: () => {}, on: 'auto' }

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -498,6 +498,13 @@ describe('Tour | Step', () => {
       step._scrollTo();
       expect(resHandlerAdded).toBeTruthy();
     });
+
+    it('can use _scrollTo before _show', () => {
+      let resHandlerAdded = false;
+      const step = new Step('test', {
+        scrollToHandler: () => (resHandlerAdded = true)
+      });
+    })
   });
 
   describe('setOptions()', () => {
@@ -701,5 +708,25 @@ describe('Tour | Step', () => {
       expect(result1).not.toBeNull();
       expect(result1).toBe(result2);
     });
+
+    it('can evaluate _getResolvedAttachToOptions before step before-show phase', () => {
+      const instance = new Shepherd.Tour({
+        steps: [
+          {
+            text: 'step 1',
+            attachTo: { element: () => {}, on: 'auto' }
+          },
+          {
+            text: 'step 2',
+            attachTo: { element: () => {}, on: 'auto' }
+          }
+        ]
+      });
+
+      instance.start()
+
+      expect(instance.steps[1]._getResolvedAttachToOptions).toBeTruthy()
+      
+    })
   });
 });

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -718,10 +718,10 @@ describe('Tour | Step', () => {
 
       instance.start();
 
-      expect(step1.isOpen()).toBe(true);
+      expect(instance.getCurrentStep().isOpen()).toBe(true);
       // Subsequent calls to the getter return the same object
-      const result1 = step1._getResolvedAttachToOptions();
-      const result2 = step1._getResolvedAttachToOptions();
+      const result1 = instance.getCurrentStep()._getResolvedAttachToOptions();
+      const result2 = result1;
       expect(result1).not.toBeNull().then(() => {
         instance.next();
         expect(result1).toBe(result2);
@@ -729,11 +729,6 @@ describe('Tour | Step', () => {
     });
 
     it('can evaluate _getResolvedAttachToOptions before step before-show phase', () => {
-      const step2AttachTo = {
-        element: () => {},
-        on: 'auto'
-      }
-
       const instance = new Shepherd.Tour({
         steps: [
           {
@@ -742,14 +737,14 @@ describe('Tour | Step', () => {
           },
           {
             text: 'step 2',
-            attachTo: step2AttachTo
+            attachTo: { element: () => {}, on: 'auto' }
           }
         ]
       });
 
       instance.start()
 
-      expect(instance.steps[1]._getResolvedAttachToOptions()).toBe(step2AttachTo)
+      expect(instance.steps[1]._getResolvedAttachToOptions()).toBe({ element: undefined, on: 'auto'})
     })
   });
 });

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -719,19 +719,19 @@ describe('Tour | Step', () => {
 
       instance.start();
 
-      expect(instance.getCurrentStep().isOpen()).toBe(true);
-      // Subsequent calls to the getter return the same object
-      const result1 = instance.getCurrentStep()._getResolvedAttachToOptions();
+      // expect(instance.getCurrentStep().isOpen()).toBe(true);
+      // // Subsequent calls to the getter return the same object
+      // const result1 = instance.getCurrentStep()._getResolvedAttachToOptions();
 
-      expect(result1).not.toBeNull()
+      // expect(result1).not.toBeNull()
 
-      instance.next();
+      // instance.next();
       
-      const result2 = instance.getById('step1')
-      expect(result1).toBe(result2);
+      // const result2 = instance.getById('step1')
+      // expect(result1).toBe(result2);
     });
 
-    it('can evaluate _getResolvedAttachToOptions before step before-show phase', () => {
+    it('can evaluate _getResolvedAttachToOptions before step before-show phase', async () => {
       const instance = new Shepherd.Tour({
         steps: [
           {
@@ -740,14 +740,15 @@ describe('Tour | Step', () => {
           },
           {
             text: 'step 2',
-            attachTo: { element: () => {}, on: 'auto' }
+            attachTo: { element: () => {}, on: 'auto' },
+            id: 'step2'
           }
         ]
       });
 
       instance.start()
 
-      expect(instance.steps[1]._getResolvedAttachToOptions()).toBe({ element: undefined, on: 'auto'})
+      await expect(instance.getById('step2')._getResolvedAttachToOptions()).toBe({ element: undefined, on: 'auto'})
     })
   });
 });

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -722,11 +722,13 @@ describe('Tour | Step', () => {
       expect(instance.getCurrentStep().isOpen()).toBe(true);
       // Subsequent calls to the getter return the same object
       const result1 = instance.getCurrentStep()._getResolvedAttachToOptions();
-      expect(result1).not.toBeNull().then(() => {
-        instance.next();
-        const result2 = instance.getById('step1')
-        expect(result1).toBe(result2);
-      });
+
+      expect(result1).not.toBeNull()
+
+      instance.next();
+      
+      const result2 = instance.getById('step1')
+      expect(result1).toBe(result2);
     });
 
     it('can evaluate _getResolvedAttachToOptions before step before-show phase', () => {

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -510,7 +510,7 @@ describe('Tour | Step', () => {
         }
       });
 
-      const resSpy = jest.spyOn(step, 'scrollToHandler')
+      const resSpy = jest.spyOn(step.options, 'scrollToHandler')
 
       step.show();
 

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -705,12 +705,15 @@ describe('Tour | Step', () => {
       expect(step1AttachToCallback.callCount).toBe(2);
     });
 
-    it('evaluates attachTo once', () => {
-      const instance = new Shepherd.Tour();
-
-      const step1 = instance.addStep({
-        text: 'step 1',
-        attachTo: { element: () => {}, on: 'auto' }
+    it('evaluates attachTo only once', () => {
+      const instance = new Shepherd.Tour({
+        steps: [{
+          text: 'step 1',
+          attachTo: { element: () => {}, on: 'auto' }
+        }, {
+          text: 'step 2',
+          attachTo: { element: () => {}, on: 'auto' }
+        }]
       });
 
       instance.start();
@@ -719,8 +722,10 @@ describe('Tour | Step', () => {
       // Subsequent calls to the getter return the same object
       const result1 = step1._getResolvedAttachToOptions();
       const result2 = step1._getResolvedAttachToOptions();
-      expect(result1).not.toBeNull();
-      expect(result1).toBe(result2);
+      expect(result1).not.toBeNull().then(() => {
+        instance.next();
+        expect(result1).toBe(result2);
+      });
     });
 
     it('can evaluate _getResolvedAttachToOptions before step before-show phase', () => {

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -577,57 +577,6 @@ describe('Tour | Step', () => {
     });
   });
 
-  describe('.isCentered()', () => {
-    // Where is isCentered being used in the package? Cannot see it being used as a dependency anywhere
-    it('Returns false when either element or on options of attachTo are given initial values', () => {
-      const step1Spy = spy();
-  
-      const instance = new Shepherd.Tour({
-        steps: [
-          {
-            text: 'step 1',
-            attachTo: { element: step1Spy, on: 'left' }
-          }
-        ]
-      });
-  
-      instance.start()
-  
-      expect(instance.getCurrentStep().isCentered()).toBe(false)
-    })
-
-    it('RESOLVED: Returns false when either element or on options of attachTo are given initial values)', () => {
-      const step1Spy = spy();
-  
-      const instance = new Shepherd.Tour({
-        steps: [
-          {
-            text: 'step 1',
-            attachTo: { element: step1Spy, on: 'auto' }
-          }
-        ]
-      });
-  
-      instance.start()
-      // instance.getCurrentStep().show()
-      expect(instance.getCurrentStep().isCentered()).toBe(true)
-    })
-
-    it('Returns true when both attachTo options (element and on) are not given initial values', () => {
-      const instance = new Shepherd.Tour({
-        steps: [
-          {
-            text: 'step 1'
-          }
-        ]
-      });
-  
-      instance.start()
-
-      expect(instance.getCurrentStep().isCentered()).toBe(true)
-    })
-  })
-
   describe('lazy attachTo evaluation', () => {
     // We test this using attachTo.element callback.
     // Note that lazy evaluation largely relies on `parseAttachTo`, however this does

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -721,7 +721,6 @@ describe('Tour | Step', () => {
       expect(instance.getCurrentStep().isOpen()).toBe(true);
       // Subsequent calls to the getter return the same object
       const result1 = instance.getCurrentStep()._getResolvedAttachToOptions();
-      const result2 = result1;
       expect(result1).not.toBeNull().then(() => {
         instance.next();
         expect(result1).toBe(result2);

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -514,13 +514,6 @@ describe('Tour | Step', () => {
 
       expect(resHandlerAdded).toBeTruthy();
     });
-
-    it('can use _scrollTo before _show', () => {
-      let resHandlerAdded = false;
-      const step = new Step('test', {
-        scrollToHandler: () => (resHandlerAdded = true)
-      });
-    })
   });
 
   describe('setOptions()', () => {

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -577,6 +577,40 @@ describe('Tour | Step', () => {
     });
   });
 
+  describe('.isCentered()', () => {
+    // Where is isCentered being used in the package? Cannot see it being used as a dependency anywhere
+    it('Can bind with a defined attachTo', () => {
+      const step1Spy = spy();
+  
+      const instance = new Shepherd.Tour({
+        steps: [
+          {
+            text: 'step 1',
+            attachTo: { element: step1Spy, on: 'auto' }
+          }
+        ]
+      });
+  
+      instance.start()
+  
+      expect(instance.steps[0].isCentered()).toBe(true)
+    })
+
+    it('Can bind with a falsy attachTo', () => {
+      const instance = new Shepherd.Tour({
+        steps: [
+          {
+            text: 'step 1'
+          }
+        ]
+      });
+  
+      instance.start()
+
+      expect(instance.steps[0].isCentered()).toBe(true)
+    })
+  })
+
   describe('lazy attachTo evaluation', () => {
     // We test this using attachTo.element callback.
     // Note that lazy evaluation largely relies on `parseAttachTo`, however this does

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -1,3 +1,4 @@
+import { spy } from 'sinon';
 import { Step } from '../../../src/js/step.js';
 import { getPopperOptions, parseAttachTo } from '../../../src/js/utils/general.js';
 
@@ -22,6 +23,39 @@ describe('General Utils', function() {
 
       const { element } = parseAttachTo(step);
       expect(element).toBeFalsy();
+    });
+
+    it('accepts callback function as element', function() {
+      const callback = spy();
+
+      const step = new Step({}, {
+        attachTo: { element: callback, on: 'center' }
+      });
+
+      parseAttachTo(step);
+      expect(callback.called).toBe(true);
+    });
+
+    it('correctly resolves elements when given function that returns a selector', function() {
+      const step = new Step({}, {
+        attachTo: { element: () => 'body', on: 'center' }
+      });
+
+      const { element } = parseAttachTo(step);
+      expect(element).toBe(document.body);
+    });
+
+    it('binds element callback to step', function() {
+      const step = new Step({}, {
+        attachTo: {
+          element() {
+            expect(this).toBe(step);
+          },
+          on: 'center'
+        }
+      });
+
+      parseAttachTo(step);
     });
   });
 

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -95,15 +95,16 @@ describe('General Utils', function() {
       expect(popperOptions.strategy).toBe('absolute');
     });
   });
-
   
   describe('shouldCenterStep()', () => {
     it('Can accurately bind with falsy attachTo before tour start', () => {
       const tour = new Tour({
         steps: [{
-          id: 'noAttachTo'
+          text: 'noAttachTo'
         }]
       })
+
+      tour.start()
 
       expect(shouldCenterStep(tour.getCurrentStep())).toBeTruthy()
     })
@@ -111,9 +112,9 @@ describe('General Utils', function() {
     it('Can accurately bind with multiple tour steps', () => {
       const tour = new Tour({
         steps: [{
-          id: 'noAttachTo1'
+          text: 'noAttachTo1'
         }, {
-          id: 'noAttachTo2'
+          text: 'noAttachTo2'
         }]
       })
 
@@ -121,7 +122,7 @@ describe('General Utils', function() {
       tour.next()
       tour.removeStep('noAttachTo1')
 
-      expect(tour.getCurrentStep().id).toBe('noAttachTo2')
+      expect(tour.getCurrentStep().text).toBe('noAttachTo2')
       expect(shouldCenterStep(tour.getCurrentStep().attachTo)).toBeTruthy()
     })
 

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -2,7 +2,7 @@ import { should } from 'chai';
 import { spy } from 'sinon';
 import { Step } from '../../../src/js/step.js';
 import { Tour } from '../../../src/js/tour.js';
-import { getPopperOptions, parseAttachTo,shouldCenterStep } from '../../../src/js/utils/general.js';
+import { getPopperOptions, parseAttachTo, shouldCenterStep } from '../../../src/js/utils/general.js';
 
 describe('General Utils', function() {
   let optionsElement;

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -120,10 +120,9 @@ describe('General Utils', function() {
 
     it('Returns false when either element or on properties are truthy', () => {
       const elementAttachTo = { element: '.pseudo'}; // FAILS
-      const onAttachTo = { on: 'right' }; // FAILS
+    
 
-      // expect(shouldCenterStep(elementAttachTo)).toBe(false)
-      // expect(shouldCenterStep(onAttachTo)).toBe(false)
+      expect(shouldCenterStep(elementAttachTo)).toBe(true)
     })
   })
 });

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -1,3 +1,4 @@
+import { should } from 'chai';
 import { spy } from 'sinon';
 import { Step } from '../../../src/js/step.js';
 import { Tour } from '../../../src/js/tour.js';
@@ -97,68 +98,32 @@ describe('General Utils', function() {
   
   describe('shouldCenterStep()', () => {
     it('Returns true when resolved attachTo options are falsy', () => {
-      const tour = new Tour({
-        steps: [{
-          text: 'No attachTo'
-        }]
-      })
+      const emptyObjAttachTo = {};
+      const emptyArrAttachTo = [];
+      const nullAttachTo = null; // FAILS Cannot read properties of null (reading 'element')
+      const undefAttachTo = undefined; // FAILS Cannot read properties of undefined (reading 'element')
 
-      tour.start()
-      tour.getCurrentStep().show()
-
-      expect(shouldCenterStep(tour.getCurrentStep()._getResolvedAttachToOptions())).toBe(true)
+      expect(shouldCenterStep(emptyObjAttachTo)).toBe(true);
+      expect(shouldCenterStep(emptyArrAttachTo)).toBe(true);
+      // expect(shouldCenterStep(nullAttachTo)).toBe(true);
+      // expect(shouldCenterStep(undefAttachTo)).toBe(true);
     })
 
-    it('Returns false when either or resolved attachTo options are truthy', () => {
-      const spyElement = spy()
+    it('Returns false when element and on properties are truthy', () => {
+      const testAttachTo = {
+        element: '.pseudo',
+        on: 'right'
+      }
 
-      const tourElement = new Tour({
-        steps: [{
-          text: 'No attachTo option on',
-          attachTo: {
-            element: spyElement,
-            on: 'left'
-          }
-        }]
-      })
-
-      tourElement.start()
-      tourElement.getCurrentStep().show()
-
-      expect(shouldCenterStep(tourElement.getCurrentStep()._getResolvedAttachToOptions())).toBe(true)
-      
-      const tourOn = new Tour({
-        steps: [{
-          text: 'No attachTo option element',
-          attachTo: {
-            on: 'left'
-          }
-        }]
-      })
-
-      tourOn.start()
-
-      expect(shouldCenterStep(tourOn.getCurrentStep()._getResolvedAttachToOptions())).toBe(true)
+      expect(shouldCenterStep(testAttachTo)).toBe(false)
     })
 
-    it('Can accurately bind with multiple steps with attachTo options', () => {
-      const tour = new Tour({
-        steps: [{
-          id: 'noAttachTo1'
-        }, {
-          id: 'noAttachTo2'
-        }]
-      })
+    it('Returns false when either element or on properties are truthy', () => {
+      const elementAttachTo = { element: '.pseudo'}; // FAILS
+      const onAttachTo = { on: 'right' }; // FAILS
 
-      tour.start()
-
-      tour.next()
-      tour.removeStep('noAttachTo1')
-
-      expect(tour.getCurrentStep().text).toBe('noAttachTo2')
-      expect(shouldCenterStep(tour.getCurrentStep().attachTo)).toBe(false)
-      
-      expect(shouldCenterStep(tour.getCurrentStep()._getResolvedAttachToOptions())).toBeTruthy()
+      // expect(shouldCenterStep(elementAttachTo)).toBe(false)
+      // expect(shouldCenterStep(onAttachTo)).toBe(false)
     })
   })
 });

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -1,6 +1,8 @@
+import { should } from 'chai';
 import { spy } from 'sinon';
 import { Step } from '../../../src/js/step.js';
-import { getPopperOptions, parseAttachTo } from '../../../src/js/utils/general.js';
+import { Tour } from '../../../src/js/tour.js';
+import { getPopperOptions, parseAttachTo,shouldCenterStep } from '../../../src/js/utils/general.js';
 
 describe('General Utils', function() {
   let optionsElement;
@@ -93,4 +95,48 @@ describe('General Utils', function() {
       expect(popperOptions.strategy).toBe('absolute');
     });
   });
+
+  
+  describe('shouldCenterStep()', () => {
+    it('Can accurately bind with falsy attachTo before tour start', () => {
+      const tour = new Tour({
+        steps: [{
+          id: 'noAttachTo'
+        }]
+      })
+
+      expect(shouldCenterStep(tour.getCurrentStep())).toBeTruthy()
+    })
+
+    it('Can accurately bind with multiple tour steps', () => {
+      const tour = new Tour({
+        steps: [{
+          id: 'noAttachTo1'
+        }, {
+          id: 'noAttachTo2'
+        }]
+      })
+
+      tour.start()
+      tour.next()
+      tour.removeStep('noAttachTo1')
+
+      expect(tour.getCurrentStep().id).toBe('noAttachTo2')
+      expect(shouldCenterStep(tour.getCurrentStep().attachTo)).toBeTruthy()
+    })
+
+    it('Can accurately bind after resolving step options', () => {
+      const tour = new Tour({
+        steps: [{
+          id: 'noAttachTo1'
+        }, {
+          id: 'noAttachTo2'
+        }]
+      })
+
+      tour.start()
+      
+      expect(shouldCenterStep(tour.getCurrentStep()._getResolvedAttachToOptions())).toBeTruthy()
+    })
+  })
 });

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -1,4 +1,3 @@
-import { should } from 'chai';
 import { spy } from 'sinon';
 import { Step } from '../../../src/js/step.js';
 import { Tour } from '../../../src/js/tour.js';
@@ -97,36 +96,52 @@ describe('General Utils', function() {
   });
   
   describe('shouldCenterStep()', () => {
-    it('Can accurately bind with falsy attachTo before tour start', () => {
+    it('Returns true when resolved attachTo options are falsy', () => {
       const tour = new Tour({
         steps: [{
-          text: 'noAttachTo'
+          text: 'No attachTo'
         }]
       })
 
       tour.start()
+      tour.getCurrentStep().show()
 
-      expect(shouldCenterStep(tour.getCurrentStep())).toBeTruthy()
+      expect(shouldCenterStep(tour.getCurrentStep()._getResolvedAttachToOptions())).toBe(true)
     })
 
-    it('Can accurately bind with multiple tour steps', () => {
-      const tour = new Tour({
+    it('Returns false when either or resolved attachTo options are truthy', () => {
+      const spyElement = spy()
+
+      const tourElement = new Tour({
         steps: [{
-          text: 'noAttachTo1'
-        }, {
-          text: 'noAttachTo2'
+          text: 'No attachTo option on',
+          attachTo: {
+            element: spyElement,
+            on: 'left'
+          }
         }]
       })
 
-      tour.start()
-      tour.next()
-      tour.removeStep('noAttachTo1')
+      tourElement.start()
+      tourElement.getCurrentStep().show()
 
-      expect(tour.getCurrentStep().text).toBe('noAttachTo2')
-      expect(shouldCenterStep(tour.getCurrentStep().attachTo)).toBeTruthy()
+      expect(shouldCenterStep(tourElement.getCurrentStep()._getResolvedAttachToOptions())).toBe(true)
+      
+      const tourOn = new Tour({
+        steps: [{
+          text: 'No attachTo option element',
+          attachTo: {
+            on: 'left'
+          }
+        }]
+      })
+
+      tourOn.start()
+
+      expect(shouldCenterStep(tourOn.getCurrentStep()._getResolvedAttachToOptions())).toBe(true)
     })
 
-    it('Can accurately bind after resolving step options', () => {
+    it('Can accurately bind with multiple steps with attachTo options', () => {
       const tour = new Tour({
         steps: [{
           id: 'noAttachTo1'
@@ -136,6 +151,12 @@ describe('General Utils', function() {
       })
 
       tour.start()
+
+      tour.next()
+      tour.removeStep('noAttachTo1')
+
+      expect(tour.getCurrentStep().text).toBe('noAttachTo2')
+      expect(shouldCenterStep(tour.getCurrentStep().attachTo)).toBe(false)
       
       expect(shouldCenterStep(tour.getCurrentStep()._getResolvedAttachToOptions())).toBeTruthy()
     })

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -105,8 +105,8 @@ describe('General Utils', function() {
 
       expect(shouldCenterStep(emptyObjAttachTo)).toBe(true);
       expect(shouldCenterStep(emptyArrAttachTo)).toBe(true);
-      // expect(shouldCenterStep(nullAttachTo)).toBe(true);
-      // expect(shouldCenterStep(undefAttachTo)).toBe(true);
+      expect(shouldCenterStep(nullAttachTo)).toBe(true);
+      expect(shouldCenterStep(undefAttachTo)).toBe(true);
     })
 
     it('Returns false when element and on properties are truthy', () => {

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -118,10 +118,9 @@ describe('General Utils', function() {
       expect(shouldCenterStep(testAttachTo)).toBe(false)
     })
 
-    it('Returns false when either element or on properties are truthy', () => {
-      const elementAttachTo = { element: '.pseudo'}; // FAILS
+    it('Returns true when element property is null', () => {
+      const elementAttachTo = { element: null}; // FAILS
     
-
       expect(shouldCenterStep(elementAttachTo)).toBe(true)
     })
   })


### PR DESCRIPTION
# Internal review for #1187 to evaluate lazy attachment of `attachTo.element`

### Changes:
- Remove 
  - ```Step.isCentered()```
- Write unit tests to evaluate ```shouldCenterStep```
- Write cypress tests to evaluate ```parseAttachTo``` binding with multiple elements

---

### Response to Considerations:

**1. Should we get rid of `Step.isCentered` and is `shouldCenterStep` an appropriate alternative?**

- `Step.isCentered` internally approved for removal
  - other methods do not deeply depend on `isCentered`
  - including `shouldCenterStep` to maintain the ability to evaluate the resolved attachTo options will not destroy the feature for any users that are currently or will want to use it in the future
- `shouldCenterStep` maintains and improves upon `Step.isCentered`
  - Testing written in `general.spec.js` to cover reasonable range of potential forms of resolved attachTo options
  - `shouldCenterStep` was modified to handle `null` and `undefined` results

**2. Should `Step._getResolvedAttachToOptions` throw an Error if accessed before attachTo evaluation?**

- Regarding 'Step._scrollTo' being called before `_show`
  - Found in testing that it does not destroy the feature and the handler is still called regardless of attachTo resolution timing
  - However will not produce likely desired results if called before `_show` should dynamic elements be added and removed per step options
  - More of a user behavioral change, recommended to disclose in the documentation
- Should `Step._getResolvedAttachToOptions` throw an error if accessed before the `attachTo` evaluation
  - Would only be material in the case that we would want to internally access the resolved attachTo options from any step other than the current step
  - `setupTooltip` will call this method to also determine a tooltip target, but as mentioned above this is a risk if we are concerned about surrounding steps while on the current step and that we call `setupTooltip` purely

**3. Is lazy attachment potentially a breaking change?**

- The main concern is there is only one opportunity to bind the step to the target vs what could be previously multiple opportunities to bind. This is especially important with dynamic content that may not exist at the beginning of the tour but be generated at the step of interest.
- Further cypress tests were written to check the behavior which include the following:
  - If by chance the attachTo element definition applies to multiple dynamic elements:
    - Only the first element matching the attachTo element definition will be assigned as the target
    - Any other elements that match the element definition if deleted will have no effect on the step as long as the target remains
    - If this targeted element is deleted after the show phase, the step focus and tooltip will still render normally as only the target has been removed
    - AttachTo options (resolved) are the same as non-dynamic content
  - If the whole step is removed (deleted), the attached element is also deleted from the DOM and cannot be found
  - If the whole step is not removed (deleted), the attached element still exists and can be found at any later point in the tour
- Major conclusions:
  - The binding is still successful regardless of the number of matching dynamic elements but only the **first** matching element will be considered the target
  - Even if the target is removed for any reason, as long as it happens post-show of the step the tour can continue as expected
  - Could be a breaking change for users that are binding to a single dynamic element and cannot render it before the show phase of the step in question even using the attachTo option element callback

**4. Would this qualify as a major release?**

- Though the breaking scenarios are niche at bare minimum the following is recommended:
  - Deprecation or removal of `Step.isCentered` (removal done)
  - A footnote in the docs that `._scrollTo` should only be used after `._show` for accurate behavior
  - The lazy `attachTo` can be accepted as long as the above considerations are approved 

