### PR TITLE
fixed showOn incorrectly skipping an index

### DIFF
--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -352,7 +352,7 @@ export class Tour extends Evented {
   _skipStep(step, forward) {
     const index = this.steps.indexOf(step);
     const nextIndex = forward ? index + 1 : index - 1;
-    if (nextIndex === this.steps.length - 1) {
+    if (index === this.steps.length - 1) {
       this.complete();
     } else {
       this.show(nextIndex, forward);

--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -351,10 +351,11 @@ export class Tour extends Evented {
    */
   _skipStep(step, forward) {
     const index = this.steps.indexOf(step);
-    const nextIndex = forward ? index + 1 : index - 1;
+
     if (index === this.steps.length - 1) {
       this.complete();
     } else {
+      const nextIndex = forward ? index + 1 : index - 1;
       this.show(nextIndex, forward);
     }
   }

--- a/test/unit/tour.spec.js
+++ b/test/unit/tour.spec.js
@@ -98,6 +98,12 @@ describe('Tour | Top-Level Class', function() {
         title: 'This is a test step for our tour'
       });
 
+      
+      instance.addStep({
+        id: 'test2',
+        title: 'Another Step'
+      });
+      
       instance.addStep({
         classes: 'skipped',
         id: 'skipped-step',
@@ -105,11 +111,6 @@ describe('Tour | Top-Level Class', function() {
         showOn() {
           return shouldShowStep;
         }
-      });
-
-      instance.addStep({
-        id: 'test2',
-        title: 'Another Step'
       });
 
       instance.addStep({
@@ -125,13 +126,13 @@ describe('Tour | Top-Level Class', function() {
       });
 
       it('adds tour steps at specified index', function() {
-        expect(instance.steps[2].options.id, 'original step at index 2').toBe('test2');
+        expect(instance.steps[1].options.id, 'original step at index 1').toBe('test2');
         instance.addStep({
           id: 'index-test',
           title: 'Test index insertion'
-        }, 2);
+        }, 1);
         expect(instance.steps.length).toBe(5);
-        expect(instance.steps[2].options.id, 'step inserted at index 2').toBe('index-test');
+        expect(instance.steps[1].options.id, 'step inserted at index 1').toBe('index-test');
       });
 
       it('adds steps with only one arg', function() {
@@ -400,6 +401,8 @@ describe('Tour | Top-Level Class', function() {
         expect(instance.getCurrentStep().id).toBe('test');
         instance.next();
         expect(instance.getCurrentStep().id).toBe('test2');
+        instance.next();
+        expect(instance.getCurrentStep().id).toBe('test3');
         expect(instance.getCurrentStep().id, 'step skipped because `showOn` returns false').not.toBe('skipped-step');
         instance.back();
         shouldShowStep = true;


### PR DESCRIPTION
The skipStep method was incorrectly checking if the next index was equal to the step length. This caused the last step to be skipped if the second to last step had a "showOn" function that returned false.

issue reported here: https://github.com/shipshapecode/shepherd/issues/1814