### PR TITLE
Update 02-usage.md, note about step header.

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -193,7 +193,7 @@ the step will execute. For example:
   ```
 - `canClickTarget` A boolean, that when set to false, will set `pointer-events: none` on the target
 - `cancelIcon` Options for the cancel icon
-  - `enabled` Should a cancel “✕” be shown in the header of the step?
+  - `enabled` Should a cancel “✕” be shown in the header of the step? Only working if a `title` is set.
   - `label` The label to add for `aria-label`
 - `classes`: A string of extra classes to add to the step's content element.
 - `buttons`: An array of buttons to add to the step. These will be rendered in a footer below the main body text. Each button in the array is an object of the format:


### PR DESCRIPTION
There's no clue in the docs how to create a step header. The cancel icon only appears if a title was set before, hence the additional note.