### PR TITLE
Fix chrome opacity bug

### DIFF
--- a/src/js/components/shepherd-modal.svelte
+++ b/src/js/components/shepherd-modal.svelte
@@ -231,6 +231,7 @@
     height: 100vh;
     opacity: 0.5;
     transition: all 0.3s ease-out, height 0s 0s, opacity 0.3s 0s;
+    -webkit-transform: translateZ(0);
   }
 
   .shepherd-modal-overlay-container.shepherd-modal-is-visible path {

--- a/src/js/components/shepherd-modal.svelte
+++ b/src/js/components/shepherd-modal.svelte
@@ -231,7 +231,7 @@
     height: 100vh;
     opacity: 0.5;
     transition: all 0.3s ease-out, height 0s 0s, opacity 0.3s 0s;
-    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
   }
 
   .shepherd-modal-overlay-container.shepherd-modal-is-visible path {


### PR DESCRIPTION
### Problem:

Shepherd modal shows opaque (black) background at load in Chrome (not observed in other browsers), but returns to 50% opacity at scroll

### Findings:

- Isolated to the `.shepherd-modal-overlay-container.shepherd-modal-is-visible` css block
- Removing the transition specifications returns to expected 50% opacity at load
- Looked into handling for css transitions in the more recent versions of chrome
  - Reference: [Fixing CSS Transitions in Google Chrome - Ben Gillbanks](https://www.binarymoon.co.uk/2014/02/fixing-css-transitions-in-google-chrome/)

### Solution:

- Add `transform` to css selector to force hardware accelerated transition with value of `0` to have no visual effect other than forcing the hardware transition

Closes #1941 