### PR TITLE
Fix for smooth scrolling

### DIFF
--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -127,7 +127,11 @@ export function getPopperOptions(attachToOptions, step) {
         fn() {
           setTimeout(() => {
             if (step.el) {
-              step.el.focus();
+              const focusOptions = {
+                preventScroll: true
+              };
+
+              step.el.focus(focusOptions);
             }
           }, 300);
         }

--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -1,6 +1,6 @@
 import { createPopper } from '@popperjs/core';
 import { isFunction, isString } from './type-check';
-import { makeCenteredPopper } from './popper-options';
+import { makeCenteredPopper, generateFocusAfterRenderModifier } from './popper-options';
 
 /**
  * Ensure class prefix ends in `-`
@@ -120,22 +120,7 @@ export function getPopperOptions(attachToOptions, step) {
           tether: false
         }
       },
-      {
-        name: 'focusAfterRender',
-        enabled: true,
-        phase: 'afterWrite',
-        fn() {
-          setTimeout(() => {
-            if (step.el) {
-              const focusOptions = {
-                preventScroll: true
-              };
-
-              step.el.focus(focusOptions);
-            }
-          }, 300);
-        }
-      }
+      generateFocusAfterRenderModifier(step)
     ],
     strategy: 'absolute'
   };

--- a/src/js/utils/popper-options.js
+++ b/src/js/utils/popper-options.js
@@ -42,7 +42,6 @@ function _getCenteredStylePopperModifier() {
  * Generates a modifier for popper that will help focus the element after it has
  * been rendered
  *
- * @export
  * @param {Step} step The step instance
  * @return {Object} The focus after render modifier configuration object
  */

--- a/src/js/utils/popper-options.js
+++ b/src/js/utils/popper-options.js
@@ -60,7 +60,11 @@ export function makeCenteredPopper(step) {
         fn() {
           setTimeout(() => {
             if (step.el) {
-              step.el.focus();
+              const focusOptions = {
+                preventScroll: true
+              };
+
+              step.el.focus(focusOptions);
             }
           }, 300);
         }

--- a/src/js/utils/popper-options.js
+++ b/src/js/utils/popper-options.js
@@ -39,6 +39,33 @@ function _getCenteredStylePopperModifier() {
 }
 
 /**
+ * Generates a modifier for popper that will help focus the element after it has
+ * been rendered
+ *
+ * @export
+ * @param {Step} step The step instance
+ * @return {Object} The focus after render modifier configuration object
+ */
+export function generateFocusAfterRenderModifier(step) {
+  return {
+    name: 'focusAfterRender',
+    enabled: true,
+    phase: 'afterWrite',
+    fn() {
+      setTimeout(() => {
+        if (step.el) {
+          const focusOptions = {
+            preventScroll: true
+          };
+
+          step.el.focus(focusOptions);
+        }
+      }, 300);
+    }
+  };
+}
+
+/**
  * Generates the array of options for a tooltip that doesn't have a
  * target element in the DOM -- and thus is positioned in the center
  * of the view
@@ -52,24 +79,7 @@ export function makeCenteredPopper(step) {
   let popperOptions = {
     placement: 'top',
     strategy: 'fixed',
-    modifiers: [
-      {
-        name: 'focusAfterRender',
-        enabled: true,
-        phase: 'afterWrite',
-        fn() {
-          setTimeout(() => {
-            if (step.el) {
-              const focusOptions = {
-                preventScroll: true
-              };
-
-              step.el.focus(focusOptions);
-            }
-          }, 300);
-        }
-      }
-    ]
+    modifiers: [generateFocusAfterRenderModifier(step)]
   };
 
   popperOptions = {

--- a/test/cypress/integration/test.acceptance.cy.js
+++ b/test/cypress/integration/test.acceptance.cy.js
@@ -525,9 +525,10 @@ describe('Shepherd Acceptance Tests', () => {
 
         cy.get('.hero-followup')
           .then((element) => calculateCenteredScrollTop(element[0]))
-          .then((scrollTop) =>
-            cy.window().its('scrollY').should('equal', scrollTop)
-          );
+          .then((scrollTop) => {
+            const plusOrMinusPx = 10;
+            cy.window().its('scrollY').should('be.closeTo', scrollTop, plusOrMinusPx)
+          });
       });
     });
   });

--- a/test/cypress/integration/test.acceptance.cy.js
+++ b/test/cypress/integration/test.acceptance.cy.js
@@ -493,6 +493,42 @@ describe('Shepherd Acceptance Tests', () => {
         tour.next();
         cy.document().get('body').should('have.prop', 'scrollTop').and('eq', 0);
       });
+
+      it('scrollTo:scrollIntoViewOptions scrolls with options', () => {
+        const scrollIntoViewOptions = {
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'nearest'
+        };
+
+        const calculateCenteredScrollTop = (target) =>
+          target.offsetTop -
+          target.offsetParent.offsetHeight / 2 +
+          target.clientHeight / 2;
+
+        const tour = setupTour(
+          Shepherd,
+          {
+            scrollTo: scrollIntoViewOptions
+          },
+          null,
+          {
+            useModalOverlay: true
+          }
+        );
+
+        // start the tour and skip a few steps ahead, so we scroll down the page a bit
+        tour.start();
+        tour.next();
+        tour.next();
+        tour.next();
+
+        cy.get('.hero-followup')
+          .then((element) => calculateCenteredScrollTop(element[0]))
+          .then((scrollTop) =>
+            cy.window().its('scrollY').should('equal', scrollTop)
+          );
+      });
     });
   });
 

--- a/test/unit/utils/general.spec.js
+++ b/test/unit/utils/general.spec.js
@@ -94,6 +94,27 @@ describe('General Utils', function() {
       const popperOptions = getPopperOptions(step.options.attachTo, step);
       expect(popperOptions.strategy).toBe('absolute');
     });
+
+    it(`has a modifier to focus on the step's element after render`, function () {
+      const step = new Step({}, {
+        attachTo: { element: '.options-test', on: 'center' },
+      });
+
+      const popperOptions = getPopperOptions(step.options.attachTo, step);
+
+      const expectedModifier = {
+        name: 'focusAfterRender',
+        enabled: true,
+        phase: 'afterWrite',
+        fn: expect.any(Function)
+      };
+
+      const actualModifier = popperOptions.modifiers.find(
+        (modifier) => modifier.name === expectedModifier.name
+      );
+
+      expect(actualModifier).toMatchObject(expectedModifier);
+    });
   });
   
   describe('shouldCenterStep()', () => {


### PR DESCRIPTION
### Description

Whenever a Tour's default step options is configured with `scrollTo: { behavior: 'smooth', block: 'center' }` the step's target may not always scroll into the center of the viewport when stepping through the tour. 

An example of this behavior can be seen on [Shepherd's welcome page](https://shepherdjs.dev)

What causes this? Shepherd’s popover receives focus while the smooth scroll to the target is in mid-transition.

The sequence of events when a tour step is first shown:
1. Smooth-scrolling to the target begins transitioning
2. After a brief delay, focus is set on the popover and [by default will also trigger a scroll](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) to the element
3. Smooth-scrolling to the target was interrupted by this shift in focus

### Changes
- Configure Shepherd’s focus with `preventScroll: true` so that it does not interrupt scrolling whenever focus shifts to the popover element
- Add supporting tests

### Demo

- Issue: https://shepherdjs.dev
- Fix: https://codepen.io/h/full/QWmgLro

https://user-images.githubusercontent.com/95371739/180328543-ee76fd36-39d4-490c-95fe-f6bef54e0421.mp4


