### PR TITLE
adjust staleLabel to better articulate its purpose

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ exemptLabels:
   - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
I'd like to propose we change the label staleBot applies on issues that get old with no movement. `wontFix` implies that that the issue is not something worth doing anything about. Changing the applied tag to `stale` will better express that the issue has simply fallen to the wayside for owners, contributors and issue OP

I've added a `stale` label so as long as there are no objections this is a one line change