### PR TITLE
Exporting StepOptionsButton type to be able to add tour steps buttons dynamically with type checking

### DIFF
--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -248,7 +248,7 @@ declare namespace Step {
     event?: string;
   }
 
-  interface StepOptionsButton {
+  export interface StepOptionsButton {
     /**
      * A function executed when the button is clicked on
      * It is automatically bound to the `tour` the step is associated with, so things like `this.next` will


### PR DESCRIPTION
I'd like to create Shepherd tour steps dynamically, with step buttons based on the index of the step. The first step would have only the Next button, steps in the middle would have Back and Next buttons, and the last step would have Back and Done buttons. Here's the code:
```
const tour = new Shepherd.Tour({...});

steps.forEach((step, i) => { // steps is an array of objects with properties text, title, and elementIdentifier
            
            // below I want to have "Shepherd.Step.StepOptionsButton" instead of "any"
            const buttons: Shepherd.Step.StepOptionsButton[] = []; 
            if (i > 0) {
                buttons.push({
                    text: "Back",
                    action: tour.back
                });
            }

            if (i < this.modelValue.steps.length - 1) {
                buttons.push({
                    text: "Next",
                    action: tour.next
                });
            }

            if (i == this.modelValue.steps.length - 1) {
                buttons.push({
                    text: "Done",
                    action: tour.complete
                });
            }

            tour.addStep({
                title: step.title,
                text: step.text,
                attachTo: {
                    element: step.elementIdentifier,
                    on: "bottom"
                },
                buttons: buttons,
                canClickTarget: false
            });
        });
...
```