### PR TITLE
Bugfix: prevent to show spurious warnings in dev panel console

### DIFF
--- a/src/js/utils/floating-ui.js
+++ b/src/js/utils/floating-ui.js
@@ -150,20 +150,11 @@ function floatingUIposition(step, shouldCenter) {
  */
 function placeArrow(el, middlewareData) {
   const arrowEl = el.querySelector('.shepherd-arrow');
-  if (arrowEl) {
-    let left, top, right, bottom;
-
-    if (middlewareData.arrow) {
-      const { x: arrowX, y: arrowY } = middlewareData.arrow;
-      left = arrowX != null ? `${arrowX}px` : '';
-      top = arrowY != null ? `${arrowY}px` : '';
-    }
-
+  if (arrowEl && middlewareData.arrow) {
+    const { x: arrowX, y: arrowY } = middlewareData.arrow;
     Object.assign(arrowEl.style, {
-      left,
-      top,
-      right,
-      bottom
+      left: arrowX != null ? `${arrowX}px` : '',
+      top: arrowY != null ? `${arrowY}px` : ''
     });
   }
 }


### PR DESCRIPTION
warnings occur in Firefox Web dev panel console when some attribute in `Element.style` component are set to `undefined`

![image](https://user-images.githubusercontent.com/2362591/211640043-2d41b834-4347-4365-9fa9-e2310172f4d3.png)
