### PR TITLE
Fix the typo in docs

### DIFF
--- a/docs-src/tutorials/04-cookbook.md
+++ b/docs-src/tutorials/04-cookbook.md
@@ -35,7 +35,7 @@ For example:
 
 ```js
 floatingUIOptions: {
-  middlewares: [offset({ mainAxis: 0, crossAxis: 12 })]
+  middleware: [offset({ mainAxis: 0, crossAxis: 12 })]
 }
 ```
 


### PR DESCRIPTION
There is a typo in examples. I have fixed this.