### PR TITLE
Remove mention to Popper on docs

### DIFF
--- a/docs-src/tutorials/04-cookbook.md
+++ b/docs-src/tutorials/04-cookbook.md
@@ -28,7 +28,7 @@ Similar results could be had by adding elements purely for the purpose of exposi
 
 ### Offsets
 
-By default, Popper instances are placed directly next to their target. However, if you need to apply some margin 
+By default, FloatingUI instances are placed directly next to their target. However, if you need to apply some margin 
 between them or if you need to fine tune the position according to some custom logic, you can use an offset middleware.
 
 For example:


### PR DESCRIPTION

Hi. 

I noticed that there is an error in the documentation. Popper is being mentioned when in fact FloatingUI should be mentioned. 

This MR fixes this. 

<img width="567" alt="Captura de pantalla 2023-01-31 a las 17 41 27" src="https://user-images.githubusercontent.com/6883041/215824806-95825e3b-4dbb-43a2-ad8d-33ee6375cc11.png">
