### PR TITLE
Added disableDefaultStepPositioning option

### DIFF
--- a/docs-src/tutorials/02-usage.md
+++ b/docs-src/tutorials/02-usage.md
@@ -224,6 +224,7 @@ You can also always manually advance the Tour by calling `myTour.next()`.
 - `modalOverlayOpeningPadding`: An amount of padding to add around the modal overlay opening
 - `modalOverlayOpeningRadius`: An amount of border radius to add around the modal overlay opening. It can be either a number or an object with properties `{ topLeft, bottomLeft, bottomRight, topRight }`
 - `floatingUIOptions`: Extra options to pass to [Floating UI](https://floating-ui.com/docs/getting-started)
+- `disableDefaultStepPositioning`: disables default automatic positioning middlewares of Shepherd, so you gain full control over it by positioning via `floatingUIOptions`.
 - `showOn`: A function that, when it returns true, will show the step. If it returns false, the step will be skipped.
 - `scrollTo`: Should the element be scrolled to when this step is shown? If true, uses the default `scrollIntoView`, if an object, passes that object as the params to `scrollIntoView` i.e. `{behavior: 'smooth', block: 'center'}`
 - `scrollToHandler`: A function that lets you override the default `scrollTo` behavior and define a custom action to do the scrolling,

--- a/docs-src/tutorials/04-cookbook.md
+++ b/docs-src/tutorials/04-cookbook.md
@@ -39,6 +39,30 @@ floatingUIOptions: {
 }
 ```
 
+### Improved positioning
+
+By default, Shepherd.js uses a number of FloatingUI middlewares to set up automatic placement of the step window. 
+However, this logic may conflict with the improved custom logic you provided via `floatingUIOptions` (i.e. Shepherd uses `flip` middleware, but it conflicts with `autoPlacement` middleware).
+In order to take over the positioning logic, you should disable the default logic with `disableDefaultStepPositioning`.
+
+For example:
+
+```javascript
+stepOptions = {
+  disableDefaultStepPositioning : true,
+  floatingUIOptions: {
+    middleware: [
+      offset(80),
+      autoPlacement(),
+      shift({
+        limiter: limitShift(),
+        crossAxis: true
+      })
+    ]
+  }
+}
+```
+
 
 ### Progress Indicator
 

--- a/src/js/utils/floating-ui.js
+++ b/src/js/utils/floating-ui.js
@@ -177,14 +177,16 @@ export function getFloatingUIOptions(attachToOptions, step) {
   const shouldCenter = shouldCenterStep(attachToOptions);
 
   if (!shouldCenter) {
-    options.middleware.push(
-      flip(),
-      // Replicate PopperJS default behavior.
-      shift({
-        limiter: limitShift(),
-        crossAxis: true
-      })
-    );
+    if (!step.options.disableDefaultStepPositioning) {
+      options.middleware.push(
+        flip(),
+        // Replicate PopperJS default behavior.
+        shift({
+          limiter: limitShift(),
+          crossAxis: true
+        })
+      );
+    }
 
     if (arrowEl) {
       options.middleware.push(arrow({ element: arrowEl }));

--- a/src/types/step.d.ts
+++ b/src/types/step.d.ts
@@ -187,6 +187,11 @@ declare namespace Step {
     floatingUIOptions?: object;
 
     /**
+     * disables default position logic of FloatingUI. Provide your logic via floatingUIOptions
+     */
+    disableDefaultStepPositioning?: boolean;
+
+    /**
      * Should the element be scrolled to when this step is shown?
      */
     scrollTo?: boolean | ScrollIntoViewOptions;

--- a/test/unit/tour.spec.js
+++ b/test/unit/tour.spec.js
@@ -619,4 +619,72 @@ describe('Tour | Top-Level Class', function() {
       expect(modalContainer.contains(modalElement)).toBe(true);
     });
   });
+
+  describe("disableDefaultStepPositioning", function() {
+
+    it('removes default middlewares', function() {
+      instance = new Shepherd.Tour({ defaultStepOptions });
+
+      const step = instance.addStep({
+        id: 'test',
+        title: 'This is a test step for our tour',
+        disableDefaultStepPositioning : true
+      });
+
+      instance.start();
+
+      const floatingUIOptions = setupTooltip(step);
+      expect(floatingUIOptions.middleware.length).toBe(1);
+      const middlewareNames = floatingUIOptions.middleware.map(({name}) => name);
+      expect(middlewareNames.includes('offset')).toBe(true);
+    });
+
+    it('adds middlewares instead of disabled default middlewares', function() {
+      const div = document.createElement('div');
+      div.classList.add('modifiers-test');
+      document.body.appendChild(div);
+      instance = new Shepherd.Tour({ defaultStepOptions });
+
+      const centeredStep = instance.addStep({
+        id: 'centered',
+        title: 'This is a centered step for our tour',
+        disableDefaultStepPositioning : true,
+        floatingUIOptions: {
+          middleware: [{name: 'foo', options: 'bar', fn: (args) => args}],
+        },
+      });
+
+      const attachedStep = instance.addStep({
+        attachTo: { element: '.modifiers-test', on: 'top' },
+        id: 'attached',
+        title: 'This is an attached step for our tour',
+        disableDefaultStepPositioning : true,
+        floatingUIOptions: {
+          middleware: [{name: 'foo', options: 'bar', fn: (args) => args}],
+        },
+      });
+
+      instance.start();
+
+      const centeredOptions = setupTooltip(centeredStep);
+      const centeredMiddlewareNames = centeredOptions.middleware.map(({name}) => name);
+      expect(centeredOptions.middleware.length).toBe(2);
+      expect(centeredMiddlewareNames.includes('offset')).toBe(true);
+      expect(centeredMiddlewareNames.includes('foo')).toBe(true);
+      expect(centeredMiddlewareNames.includes('arrow')).toBe(false);
+
+      instance.next();
+
+      const options = setupTooltip(attachedStep);
+      const middlewareNames = options.middleware.map(({name}) => name);
+      expect(options.middleware.length).toBe(3);
+      expect(middlewareNames.includes('offset')).toBe(true);
+      expect(middlewareNames.includes('foo')).toBe(true);
+      expect(middlewareNames.includes('shift')).toBe(false);
+      expect(middlewareNames.includes('arrow')).toBe(true);
+
+      document.body.removeChild(div);
+    });
+
+  })
 });


### PR DESCRIPTION
One may find `autoPlacement` middleware much more reliable (and less glitchy) for complex applications (including hybrid applications), but Shepherd.js uses `flip` middleware by default without any chance to override it.
This modification allows us to completely take over the placement logic of FloatingUI used in Shepherd for step positioning.