### PR TITLE
Prevent ESC, KEY_RIGHT, KEY_LEFT propagation when keyboardNav is enabled

### DIFF
--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -92,16 +92,19 @@
         break;
       case KEY_ESC:
         if (tour.options.exitOnEsc) {
+          e.stopPropagation();
           step.cancel();
         }
         break;
       case LEFT_ARROW:
         if (tour.options.keyboardNavigation) {
+          e.stopPropagation();
           tour.back();
         }
         break;
       case RIGHT_ARROW:
         if (tour.options.keyboardNavigation) {
+          e.stopPropagation();
           tour.next();
         }
         break;

--- a/test/unit/components/shepherd-element.spec.js
+++ b/test/unit/components/shepherd-element.spec.js
@@ -76,9 +76,17 @@ describe('components/ShepherdElement', () => {
     it('keyboardNavigation: true - arrow keys move between steps', async() => {
       const tour = new Tour();
       const step = new Step(tour, {});
+      let propagateValue = null;
 
       const tourBackStub = stub(tour, 'back');
       const tourNextStub = stub(tour, 'next');
+
+      document.body.addEventListener('keydown', (event) => {
+        // listen to ESC, KEY_RIGHT, KEY_LEFT
+        if ([27, 37, 39].includes(event.keyCode)) {
+          propagateValue = 1;
+        }
+      });
 
       expect(tourBackStub.called).toBe(false);
       expect(tourNextStub.called).toBe(false);
@@ -90,9 +98,11 @@ describe('components/ShepherdElement', () => {
       });
       fireEvent.keyDown(container.querySelector('.shepherd-element'), { keyCode: 39 });
       expect(tourNextStub.called).toBe(true);
+      expect(propagateValue).toBe(null);
 
       fireEvent.keyDown(container.querySelector('.shepherd-element'), { keyCode: 37 });
       expect(tourBackStub.called).toBe(true);
+      expect(propagateValue).toBe(null);
 
       tourBackStub.restore();
       tourNextStub.restore();
@@ -101,9 +111,17 @@ describe('components/ShepherdElement', () => {
     it('keyboardNavigation: false - arrow keys do not move between steps', async() => {
       const tour = new Tour({ keyboardNavigation: false });
       const step = new Step(tour, {});
+      let propagateValue = null;
 
       const tourBackStub = stub(tour, 'back');
       const tourNextStub = stub(tour, 'next');
+
+      document.body.addEventListener('keydown', (event) => {
+        // listen to ESC, KEY_RIGHT, KEY_LEFT
+        if ([27, 37, 39].includes(event.keyCode)) {
+          propagateValue = 1;
+        }
+      });
 
       expect(tourBackStub.called).toBe(false);
       expect(tourNextStub.called).toBe(false);
@@ -115,9 +133,11 @@ describe('components/ShepherdElement', () => {
       });
       fireEvent.keyDown(container.querySelector('.shepherd-element'), { keyCode: 39 });
       expect(tourNextStub.called).toBe(false);
+      expect(propagateValue).toBe(1);
 
       fireEvent.keyDown(container.querySelector('.shepherd-element'), { keyCode: 37 });
       expect(tourBackStub.called).toBe(false);
+      expect(propagateValue).toBe(1);
 
       tourBackStub.restore();
       tourNextStub.restore();

--- a/test/unit/components/shepherd-element.spec.js
+++ b/test/unit/components/shepherd-element.spec.js
@@ -76,15 +76,16 @@ describe('components/ShepherdElement', () => {
     it('keyboardNavigation: true - arrow keys move between steps', async() => {
       const tour = new Tour();
       const step = new Step(tour, {});
-      let propagateValue = null;
+      let propagateValue = 0;
 
       const tourBackStub = stub(tour, 'back');
       const tourNextStub = stub(tour, 'next');
 
+      // Add a keystroke listener to a parent to test event propagation
       document.body.addEventListener('keydown', (event) => {
         // listen to ESC, KEY_RIGHT, KEY_LEFT
         if ([27, 37, 39].includes(event.keyCode)) {
-          propagateValue = 1;
+          propagateValue += 1;
         }
       });
 
@@ -98,11 +99,13 @@ describe('components/ShepherdElement', () => {
       });
       fireEvent.keyDown(container.querySelector('.shepherd-element'), { keyCode: 39 });
       expect(tourNextStub.called).toBe(true);
-      expect(propagateValue).toBe(null);
+      // There should be no event propagation
+      expect(propagateValue).toBe(0);
 
       fireEvent.keyDown(container.querySelector('.shepherd-element'), { keyCode: 37 });
       expect(tourBackStub.called).toBe(true);
-      expect(propagateValue).toBe(null);
+      // There should be no event propagation
+      expect(propagateValue).toBe(0);
 
       tourBackStub.restore();
       tourNextStub.restore();
@@ -111,15 +114,16 @@ describe('components/ShepherdElement', () => {
     it('keyboardNavigation: false - arrow keys do not move between steps', async() => {
       const tour = new Tour({ keyboardNavigation: false });
       const step = new Step(tour, {});
-      let propagateValue = null;
+      let propagateValue = 0;
 
       const tourBackStub = stub(tour, 'back');
       const tourNextStub = stub(tour, 'next');
 
+      // Add a keystroke listener to a parent to test event propagation
       document.body.addEventListener('keydown', (event) => {
         // listen to ESC, KEY_RIGHT, KEY_LEFT
         if ([27, 37, 39].includes(event.keyCode)) {
-          propagateValue = 1;
+          propagateValue += 1;
         }
       });
 
@@ -133,11 +137,13 @@ describe('components/ShepherdElement', () => {
       });
       fireEvent.keyDown(container.querySelector('.shepherd-element'), { keyCode: 39 });
       expect(tourNextStub.called).toBe(false);
+      // There should be event propagation
       expect(propagateValue).toBe(1);
 
       fireEvent.keyDown(container.querySelector('.shepherd-element'), { keyCode: 37 });
       expect(tourBackStub.called).toBe(false);
-      expect(propagateValue).toBe(1);
+      // There should be another event propagation
+      expect(propagateValue).toBe(2);
 
       tourBackStub.restore();
       tourNextStub.restore();


### PR DESCRIPTION
This pull prevents key down event propagation on ESC, KEY_RIGHT, KEY_LEFT keys in Shepherd, when the Shepherd keyboardNavigation is enabled in a shepherd tour.

The reason: our underlying web application, like may others, has a listener for ESC, KEY_RIGHT, KEY_LEFT key press to enable shortcut actions. When the Shepherd "onboarding" tour is played and the user uses keyboardNav, our underlying web application also receives the KEY_RIGHT, KEY_LEFT, and ESC events and also handles them. This causes havoc and confusion with the underlying web application doing things that the user did not intend while they were only trying to navigate the Shepherd tour.