### PR TITLE
refactor: replace string continuations with template literals for improved readability

### DIFF
--- a/shepherd.js/src/utils/overlay-path.ts
+++ b/shepherd.js/src/utils/overlay-path.ts
@@ -39,19 +39,19 @@ export function makeOverlayPath({
     ? { topLeft: r, topRight: r, bottomRight: r, bottomLeft: r }
     : r;
 
-  return `M${w},${h}\
-H0\
-V0\
-H${w}\
-V${h}\
-Z\
-M${x + topLeft},${y}\
-a${topLeft},${topLeft},0,0,0-${topLeft},${topLeft}\
-V${height + y - bottomLeft}\
-a${bottomLeft},${bottomLeft},0,0,0,${bottomLeft},${bottomLeft}\
-H${width + x - bottomRight}\
-a${bottomRight},${bottomRight},0,0,0,${bottomRight}-${bottomRight}\
-V${y + topRight}\
-a${topRight},${topRight},0,0,0-${topRight}-${topRight}\
+  return `M${w},${h}
+H0
+V0
+H${w}
+V${h}
+Z
+M${x + topLeft},${y}
+a${topLeft},${topLeft},0,0,0-${topLeft},${topLeft}
+V${height + y - bottomLeft}
+a${bottomLeft},${bottomLeft},0,0,0,${bottomLeft},${bottomLeft}
+H${width + x - bottomRight}
+a${bottomRight},${bottomRight},0,0,0,${bottomRight}-${bottomRight}
+V${y + topRight}
+a${topRight},${topRight},0,0,0-${topRight}-${topRight}
 Z`;
 }


### PR DESCRIPTION
As per issue #2566,
This commit replaces the use of string continuations with template literals to enhance code readability and maintainability. Template literals provide a cleaner way to handle multi-line strings, making the code easier to understand and reducing the risk of syntax errors caused by misplaced backslashes.


Attached is the makeOverlayPath.test.js file with test cases for the changes in the commit

`import { makeOverlayPath } from '../utils/overlay-path.ts';
describe('makeOverlayPath', () => {
  it('should return the correct path string', () => {
    const w = 10;
    const h = 20;
    const x = 5;
    const y = 5;
    const topLeft = 2;
    const bottomLeft = 3;
    const bottomRight = 4;
    const topRight = 1;
    const width = 50;
    const height = 100;

    const expectedPath = `M10,20
H0
V0
H10
V20
Z
M7,5
a2,2,0,0,0-2,2
V102
a3,3,0,0,0,3,3
H51
a4,4,0,0,0,4-4
V6
a1,1,0,0,0-1-1
Z`;

    expect(makeOverlayPath(w, h, x, y, topLeft, bottomLeft, bottomRight, topRight, width, height)).toBe(expectedPath);
  });

  it('should handle edge cases with zero values', () => {
    const w = 0;
    const h = 0;
    const x = 0;
    const y = 0;
    const topLeft = 0;
    const bottomLeft = 0;
    const bottomRight = 0;
    const topRight = 0;
    const width = 0;
    const height = 0;

    const expectedPath = `M0,0
H0
V0
H0
V0
Z
M0,0
a0,0,0,0,0-0,0
V0
a0,0,0,0,0,0,0
H0
a0,0,0,0,0,0-0
V0
a0,0,0,0,0-0-0
Z`;

    expect(makeOverlayPath(w, h, x, y, topLeft, bottomLeft, bottomRight, topRight, width, height)).toBe(expectedPath);
  });
});
`