### PR TITLE
Add 'auto' as placement option

### DIFF
--- a/docs-src/src/content/docs/guides/usage.md
+++ b/docs-src/src/content/docs/guides/usage.md
@@ -176,7 +176,7 @@ created.
 - `attachTo`: The element the step should be attached to on the page. An object with properties `element` and `on`.
   - `element`: An element selector string, a DOM element, or a function (returning a selector, a DOM element, `null` or `undefined`).
   - `on`: The optional direction to place the Floating UI tooltip relative to the element.
-    - Possible string values: 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'
+    - Possible string values: 'auto', 'auto-start', 'auto-end', 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'
 
 ```js
 const new Step(tour, {

--- a/shepherd.js/src/step.ts
+++ b/shepherd.js/src/step.ts
@@ -187,6 +187,9 @@ export interface StepOptions {
 }
 
 export type PopperPlacement =
+  | 'auto'
+  | 'auto-start'
+  | 'auto-end'
   | 'top'
   | 'top-start'
   | 'top-end'

--- a/test/unit/tour.spec.js
+++ b/test/unit/tour.spec.js
@@ -666,6 +666,60 @@ describe('Tour | Top-Level Class', function () {
 
       expect(stepsContainer.contains(stepElement)).toBe(true);
     });
+
+    it('adds autoPlacement middleware when attachTo.on is set to auto', () => {
+      const div = document.createElement('div');
+      div.classList.add('modifiers-test');
+      document.body.appendChild(div);
+      instance = new Shepherd.Tour();
+
+      const step1 = instance.addStep({
+        id: 'test',
+        title: 'This is a test step for our tour',
+        attachTo: { element: '.modifiers-test', on: 'auto' }
+      });
+
+      const step2 = instance.addStep({
+        id: 'test',
+        title: 'This is a test step for our tour',
+        attachTo: { element: '.modifiers-test', on: 'auto-start' }
+      });
+
+      const step3 = instance.addStep({
+        id: 'test',
+        title: 'This is a test step for our tour',
+        attachTo: { element: '.modifiers-test', on: 'auto-end' }
+      });
+
+      instance.start();
+
+      const step1FloatingUIOptions = setupTooltip(step1);
+      const step1MiddlewareNames = step1FloatingUIOptions.middleware.map(
+        ({ name }) => name
+      );
+      const step1PlacementMiddleware = step1FloatingUIOptions.middleware.find(
+        ({ name }) => name === 'autoPlacement'
+      );
+      expect(step1MiddlewareNames.includes('autoPlacement')).toBe(true);
+      expect(step1MiddlewareNames.includes('flip')).toBe(false);
+      expect(step1PlacementMiddleware.options.alignment).toBe(null);
+
+      instance.next();
+
+      const step2FloatingUIOptions = setupTooltip(step2);
+      const step2PlacementMiddleware = step2FloatingUIOptions.middleware.find(
+        ({ name }) => name === 'autoPlacement'
+      );
+      expect(step2PlacementMiddleware.options.alignment).toBe('start');
+
+      instance.next();
+
+      const step3FloatingUIOptions = setupTooltip(step3);
+      const step3PlacementMiddleware = step3FloatingUIOptions.middleware.find(
+        ({ name }) => name === 'autoPlacement'
+      );
+      expect(step3PlacementMiddleware.options.alignment).toBe('end');
+    });
   });
 
   describe('shepherdModalOverlayContainer', function () {


### PR DESCRIPTION
## About
As discussed in #2583, adding `autoPlacement` is not possible due to `flip` being automatically added by shepherd. This PR re-introduces `auto` placements, which were removed a couple of versions back with migration from popper to floating-ui.

When step `attachTo.on` is set to `auto[-start|end]`, we automatically add [`autoPlacement`](https://floating-ui.com/docs/autoPlacement) to the middlewares and remove `flip`, which isn’t compatible with it.

### Proposed changes

- add `auto[-start|end]` placement options, which were removed when popper was replaced with floating-ui
   https://github.com/shipshapecode/shepherd/blob/76fe594ccdf125c42ceddbaa44e017497d8c441a/src/types/step.d.ts#L232

Let me know if there’s any changes you want me to make 🙏 