### PR TITLE
Fix options type for `options.floatingUIOptions`

### DIFF
--- a/shepherd.js/src/step.ts
+++ b/shepherd.js/src/step.ts
@@ -17,6 +17,7 @@ import {
 // @ts-expect-error TODO: we don't have Svelte .d.ts files until we generate the dist
 import ShepherdElement from './components/shepherd-element.svelte';
 import { type Tour } from './tour.ts';
+import type { ComputePositionConfig } from '@floating-ui/dom';
 
 export type StepText =
   | string
@@ -134,7 +135,7 @@ export interface StepOptions {
   /**
    * Extra [options to pass to FloatingUI]{@link https://floating-ui.com/docs/tutorial/}
    */
-  floatingUIOptions?: object;
+  floatingUIOptions?: ComputePositionConfig;
 
   /**
    * Should the element be scrolled to when this step is shown?

--- a/shepherd.js/src/utils/floating-ui.ts
+++ b/shepherd.js/src/utils/floating-ui.ts
@@ -63,7 +63,7 @@ export function setupTooltip(step: Step): ComputePositionConfig {
 export function mergeTooltipConfig(
   tourOptions: StepOptions,
   options: StepOptions
-) {
+): { floatingUIOptions: ComputePositionConfig } {
   return {
     floatingUIOptions: deepmerge(
       tourOptions.floatingUIOptions || {},


### PR DESCRIPTION
## About

Shepherd is already using `ComputePositionConfig` internally in a few places, but the options object itself is typed as `object`, which isn’t really helpful. Not sure if this is done because of some problem with docs — feel free to close this PR in that case!

### Proposed changes

*   add correct type to `Step.floatingUIOptions`