### PR TITLE
Middleware deduping

### DIFF
--- a/shepherd.js/src/step.ts
+++ b/shepherd.js/src/step.ts
@@ -8,7 +8,12 @@ import {
   isUndefined
 } from './utils/type-check.ts';
 import { bindAdvance } from './utils/bind.ts';
-import { parseAttachTo, normalizePrefix, uuid } from './utils/general.ts';
+import {
+  parseAttachTo,
+  normalizePrefix,
+  uuid,
+  dedupeMiddlewares
+} from './utils/general.ts';
 import {
   setupTooltip,
   destroyTooltip,
@@ -521,6 +526,13 @@ export class Step extends Evented {
       this.tour && this.tour.options && this.tour.options.defaultStepOptions;
 
     tourOptions = deepmerge({}, tourOptions || {});
+
+    if (tourOptions.floatingUIOptions?.middleware) {
+      tourOptions.floatingUIOptions.middleware = dedupeMiddlewares(
+        [...tourOptions.floatingUIOptions.middleware],
+        options.floatingUIOptions?.middleware
+      );
+    }
 
     this.options = Object.assign(
       {

--- a/shepherd.js/src/utils/floating-ui.ts
+++ b/shepherd.js/src/utils/floating-ui.ts
@@ -1,5 +1,5 @@
 import { deepmerge } from 'deepmerge-ts';
-import { shouldCenterStep } from './general.ts';
+import { dedupeMiddlewares, shouldCenterStep } from './general.ts';
 import {
   autoUpdate,
   arrow,
@@ -201,6 +201,11 @@ export function getFloatingUIOptions(
 
     options.placement = attachToOptions.on;
   }
+
+  options.middleware = dedupeMiddlewares(
+    options.middleware,
+    step.options.floatingUIOptions?.middleware
+  );
 
   return deepmerge(options, step.options.floatingUIOptions || {});
 }

--- a/shepherd.js/src/utils/general.ts
+++ b/shepherd.js/src/utils/general.ts
@@ -94,7 +94,7 @@ export function uuid() {
 export function dedupeMiddlewares(
   defaultMiddlewares?: ComputePositionConfig['middleware'],
   stepMiddlewares?: ComputePositionConfig['middleware']
-) {
+): ComputePositionConfig['middleware'] {
   return defaultMiddlewares?.filter(
     (defaultMiddleware) =>
       !defaultMiddleware ||

--- a/shepherd.js/src/utils/general.ts
+++ b/shepherd.js/src/utils/general.ts
@@ -5,6 +5,7 @@ import {
   type StepOptions
 } from '../step.ts';
 import { isFunction, isString } from './type-check.ts';
+import type { ComputePositionConfig } from '@floating-ui/dom';
 
 export class StepNoOp {
   constructor(_options: StepOptions) {}
@@ -88,4 +89,18 @@ export function uuid() {
     d = Math.floor(d / 16);
     return (c == 'x' ? r : (r & 0x3) | 0x8).toString(16);
   });
+}
+
+export function dedupeMiddlewares(
+  defaultMiddlewares?: ComputePositionConfig['middleware'],
+  stepMiddlewares?: ComputePositionConfig['middleware']
+) {
+  return defaultMiddlewares?.filter(
+    (defaultMiddleware) =>
+      !defaultMiddleware ||
+      !stepMiddlewares?.some(
+        (stepMiddleware) =>
+          stepMiddleware && stepMiddleware.name === defaultMiddleware.name
+      )
+  );
 }

--- a/test/unit/step.spec.js
+++ b/test/unit/step.spec.js
@@ -88,8 +88,8 @@ describe('Tour | Step', () => {
     });
 
     const stepWithoutNameWithoutIdOffsetMiddleware = offset({
-      mainAxis: 0,
-      crossAxis: -32
+      mainAxis: 32,
+      crossAxis: 0
     });
     const stepWithoutNameWithoutId = instance.addStep({
       attachTo: { element: 'body' },
@@ -181,16 +181,11 @@ describe('Tour | Step', () => {
         stepWithoutNameWithoutId.options.floatingUIOptions.middleware.filter(
           ({ name }) => name === 'offset'
         );
-      const offsetResult = offsetMiddleware.reduce(
-        (agg, current) => {
-          agg.mainAxis += current.options.mainAxis;
-          agg.crossAxis += current.options.crossAxis;
-          return agg;
-        },
-        { mainAxis: 0, crossAxis: 0 }
-      );
-
-      expect(offsetResult).toEqual({ mainAxis: 0, crossAxis: 0 });
+      expect(offsetMiddleware.length).toBe(1);
+      expect(offsetMiddleware[0].options).toEqual({
+        mainAxis: 32,
+        crossAxis: 0
+      });
     });
 
     describe('.hide()', () => {

--- a/test/unit/tour.spec.js
+++ b/test/unit/tour.spec.js
@@ -666,6 +666,45 @@ describe('Tour | Top-Level Class', function () {
 
       expect(stepsContainer.contains(stepElement)).toBe(true);
     });
+
+    it.only('deduplicates middlewares', () => {
+      instance = new Shepherd.Tour({
+        defaultStepOptions: {
+          floatingUIOptions: {
+            middleware: [{ name: 'foo', options: 'bar', fn: (args) => args }]
+          }
+        }
+      });
+
+      const step = instance.addStep({
+        id: 'test',
+        title: 'This is a test step for our tour',
+        floatingUIOptions: {
+          middleware: [{ name: 'foo', options: 'bar', fn: (args) => args }]
+        }
+      });
+
+      const step2 = instance.addStep({
+        id: 'test',
+        title: 'This is a test step for our tour',
+        floatingUIOptions: {
+          middleware: [
+            { name: 'foo', options: 'bar', fn: (args) => args },
+            { name: 'bar', options: 'bar', fn: (args) => args }
+          ]
+        }
+      });
+
+      instance.start();
+
+      const step1FloatingUIOptions = setupTooltip(step);
+      expect(step1FloatingUIOptions.middleware.length).toBe(1);
+
+      instance.next();
+
+      const step2FloatingUIOptions = setupTooltip(step2);
+      expect(step2FloatingUIOptions.middleware.length).toBe(2);
+    });
   });
 
   describe('shepherdModalOverlayContainer', function () {


### PR DESCRIPTION
## About

This might be a controversial (and breaking) change, but instead of overriding middlewares, I think the step middleware should always win. Feel free to close this PR or message me to make changes.

Take this example:

```
const defaultStepOptions = {
  floatingUIOptions: {
    middleware: [offset({ crossAxis: 32 })]
  }
};

const stepOptions = {
  floatingUIOptions: {
    middleware: [offset({ crossAxis: -32 })]
  }
}
```

To override `defaultStepOptions` you need equal negative spacing and sync these two numbers every time the default changes (or have a constant)

With this PR:

```
const defaultStepOptions = {
  floatingUIOptions: {
    middleware: [offset({ crossAxis: 32 })]
  }
};

const stepOptions = {
  floatingUIOptions: {
    middleware: [offset({ crossAxis: 0 })]
  }
}
```

The step offset middleware overrides the default step middleware