### PR TITLE
♿ Remove tabindex to reduce tabs for modal trap

### DIFF
--- a/shepherd.js/src/components/shepherd-content.svelte
+++ b/shepherd.js/src/components/shepherd-content.svelte
@@ -7,7 +7,7 @@
   export let descriptionId, labelId, step;
 </script>
 
-<div class="shepherd-content" tabindex="0">
+<div class="shepherd-content">
   {#if !isUndefined(step.options.title) || (step.options.cancelIcon && step.options.cancelIcon.enabled)}
     <ShepherdHeader {labelId} {step} />
   {/if}

--- a/test/cypress/integration/a11y.cy.js
+++ b/test/cypress/integration/a11y.cy.js
@@ -75,7 +75,8 @@ describe('a11y', () => {
 
       cy.document().then(() => {
         cy.wait(1000);
-        cy.get('.shepherd-content').tab().tab().tab().tab().tab().tab().tab();
+        // Tabbing out of the modal should not be possible and we test this by tabbing from the body
+        cy.get('body').tab().tab().tab().tab().tab().tab();
         cy.get('[data-test-popper-link]').should('have.focus');
       });
     });


### PR DESCRIPTION
closes #3071 

This removes the tabindex added by the content div that's not needed for tab trapping in the dialog. 