### PR TITLE
Fix skipping of event handlers

### DIFF
--- a/shepherd.js/src/evented.ts
+++ b/shepherd.js/src/evented.ts
@@ -77,7 +77,7 @@ export class Evented {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   trigger(event: string, ...args: any[]) {
     if (!isUndefined(this.bindings) && this.bindings[event]) {
-      this.bindings[event]?.forEach((binding, index) => {
+      this.bindings[event]?.slice().forEach((binding, index) => {
         const { ctx, handler, once } = binding;
 
         const context = ctx || this;

--- a/test/unit/evented.spec.js
+++ b/test/unit/evented.spec.js
@@ -38,6 +38,14 @@ describe('Evented', () => {
         step: { id: 'test', text: 'A step' }
       });
     });
+
+    it('does not skip event bindings after removing an event binding', () => {
+      testEvent.once('testOn', () => true);
+      const handlerSpy = jest.fn();
+      testEvent.on('testOn', handlerSpy);
+      testEvent.trigger('testOn');
+      expect(handlerSpy).toHaveBeenCalled();
+    });
   });
 
   describe('off()', () => {


### PR DESCRIPTION
Event handlers registered after a `once` handler were being silently skipped, causing unpredictable behaviour in tour interactions. This occurred because modifying an array during iteration is unsafe.

Making a copy of the bindings array before iteration prevents these handers from being skipped.