### PR TITLE
Update README example path

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -20,7 +20,7 @@ npm install --save react-shepherd
 
 ```tsx
 import { Component, useContext } from 'react';
-import { ShepherdJourneyProvider, useShepherd } from '@shepherdpro/react';
+import { ShepherdJourneyProvider, useShepherd } from 'react-shepherd';
 import newSteps from './steps';
 
 const tourOptions = {


### PR DESCRIPTION
Update wrong import path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated import path example in the React package README to reflect current package naming conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->