### PR TITLE
fix: not call destroy on destroyed step

### DIFF
--- a/shepherd.js/src/step.ts
+++ b/shepherd.js/src/step.ts
@@ -5,7 +5,8 @@ import {
   isElement,
   isHTMLElement,
   isFunction,
-  isUndefined
+  isUndefined,
+  isNull
 } from './utils/type-check.ts';
 import { bindAdvance } from './utils/bind.ts';
 import {
@@ -699,7 +700,7 @@ export class Step extends Evented {
    * @private
    */
   _setupElements() {
-    if (!isUndefined(this.el)) {
+    if (!isUndefined(this.el) && !isNull(this.el)) {
       this.destroy();
     }
 

--- a/shepherd.js/src/utils/type-check.ts
+++ b/shepherd.js/src/utils/type-check.ts
@@ -37,3 +37,11 @@ export function isString<T>(value: T | string): value is string {
 export function isUndefined<T>(value: T | undefined): value is undefined {
   return value === undefined;
 }
+
+/**
+ * Checks if `value` is null.
+ * @param value The param to check if it is null
+ */
+export function isNull<T>(value: T | undefined | null): value is null {
+  return value === null;
+}

--- a/shepherd.js/test/unit/step.spec.js
+++ b/shepherd.js/test/unit/step.spec.js
@@ -441,6 +441,19 @@ describe('Tour | Step', () => {
       ).toBeTruthy();
     });
 
+    it('not calls destroy on the step if the step was destroyed', () => {
+      const step = new Step(tour, {});
+      let destroyCalled = false;
+      step.el = document.createElement('a');
+      step.destroy();
+      step.destroy = () => (destroyCalled = true);
+      step._setupElements();
+      expect(
+        destroyCalled,
+        '_setupElements method not called destroy if the step was destroyed'
+      ).toBeFalsy();
+    });
+
     it('calls destroy on the tooltip if it already exists', () => {
       const step = new Step(tour, {});
       let destroyCalled = false;


### PR DESCRIPTION
Currently on function `_setupElements` of step, the destroy function is called if `this.el` is undefined but the destroy method set `this.el` to null. So function `destroy` is called also on destroyed element which trigger unnecessary 'destroy' event. 

Another possible change would be to change the condition in `_setupElements` to check if `this.el` is either undefined or null. 

This is linked with reported issue https://github.com/shipshapecode/shepherd/issues/3443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `isNull` type-guard utility for reliably detecting `null` values.

* **Bug Fixes**
  * Improved step element setup/teardown handling to better account for `null` vs `undefined`, and to avoid redundant teardown when a step has already been destroyed.

* **Tests**
  * Expanded unit coverage to confirm teardown isn’t triggered again on already-destroyed steps, even if `destroy` is later replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->