### PR TITLE
fix: allow TypeScript 6 and 7 as peer dependencies for react-shepherd

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",


### PR DESCRIPTION
react-shepherd declared `typescript@^5.0.0` as a peer dependency, which made `npm install` fail with a peer-resolution conflict for consumers on TypeScript 6 (npm strict peer deps). This relaxes the range to `^5.0.0 || ^6.0.0 || ^7.0.0`.

Closes #3445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded TypeScript compatibility for the React package to support versions 5, 6, and 7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->