### PR TITLE
fix: pass the actual previous step in the Tour `show` event

### DIFF
--- a/shepherd.js/src/tour.ts
+++ b/shepherd.js/src/tour.ts
@@ -400,10 +400,12 @@ export class Tour extends Evented {
    * @private
    */
   _showStep(step: Step) {
+    const previous = this.currentStep;
+
     this.currentStep = step;
     this.trigger('show', {
       step,
-      previous: this.currentStep
+      previous
     });
 
     step.show();

--- a/shepherd.js/src/tour.ts
+++ b/shepherd.js/src/tour.ts
@@ -400,7 +400,9 @@ export class Tour extends Evented {
    * @private
    */
   _showStep(step: Step) {
-    const previous = this.currentStep;
+    // `currentStep` is `undefined` until a step has shown, so normalize to
+    // `null` to keep `previous` consistent across every path into `show`
+    const previous = this.currentStep ?? null;
 
     this.currentStep = step;
     this.trigger('show', {

--- a/shepherd.js/test/unit/tour.spec.js
+++ b/shepherd.js/test/unit/tour.spec.js
@@ -561,6 +561,23 @@ describe('Tour | Top-Level Class', function () {
         ).not.toBe(secondShow.step);
       });
 
+      it('reports `previous` as null when no step was showing before', function () {
+        // `removeStep` clears `currentStep` to `undefined` before showing the
+        // next step, so `previous` has to be normalized on that path too
+        instance.start();
+
+        let previousStep;
+        instance.on('show', ({ previous }) => (previousStep = previous));
+
+        instance.removeStep('test');
+
+        expect(instance.getCurrentStep().id).toBe('test2');
+        expect(
+          previousStep,
+          '`previous` is null rather than undefined when nothing was showing'
+        ).toBeNull();
+      });
+
       it('showOn determines which steps to skip', function () {
         instance.start();
         expect(instance.getCurrentStep().id).toBe('test');

--- a/shepherd.js/test/unit/tour.spec.js
+++ b/shepherd.js/test/unit/tour.spec.js
@@ -533,6 +533,34 @@ describe('Tour | Top-Level Class', function () {
         ).toBeFalsy();
       });
 
+      it('triggers show with the step that was showing before as `previous`', function () {
+        const shows = [];
+        instance.on('show', ({ step, previous }) =>
+          shows.push({ step, previous })
+        );
+
+        instance.start();
+        instance.next();
+
+        const [firstShow, secondShow] = shows;
+
+        expect(firstShow.step.id).toBe('test');
+        expect(
+          firstShow.previous,
+          'there is no previous step on the first show'
+        ).toBeNull();
+
+        expect(secondShow.step.id).toBe('test2');
+        expect(
+          secondShow.previous.id,
+          '`previous` is the step that was showing before'
+        ).toBe('test');
+        expect(
+          secondShow.previous,
+          '`previous` is not the same object as `step`'
+        ).not.toBe(secondShow.step);
+      });
+
       it('showOn determines which steps to skip', function () {
         instance.start();
         expect(instance.getCurrentStep().id).toBe('test');


### PR DESCRIPTION
The `show` event payload has always reported `previous` incorrectly.

## The bug

`Tour._showStep` reassigned `currentStep` *before* building the event payload:

```ts
this.currentStep = step;
this.trigger("show", {
  step,
  previous: this.currentStep  // already reassigned — same object as `step`
});
```

So `previous` read back the step being shown. It was always `=== step`, and never the step that was actually showing before.

## The documented contract

`docs-src/src/content/docs/guides/usage.md` ("Tour Events") states:

> `show`: Triggered with a hash of the `step` and the `previous` step

The behavior contradicted the docs, so consumers relying on `previous` to detect direction or clean up the outgoing step got the wrong object.

## The fix

Capture `currentStep` before the reassignment, normalized to `null`:

```ts
const previous = this.currentStep ?? null;

this.currentStep = step;
this.trigger("show", { step, previous });
```

The `?? null` matters because `currentStep` is `Step | null | undefined` and only `start()` initializes it to `null`. `removeStep()` sets it to `undefined` before calling `show(0)`, so without normalizing, that path reported `previous: undefined` while the start path reported `null`. Now `previous` is consistently `null` when nothing was showing before.

Placing this in `_showStep` covers every route into it, including the async `waitForElement` path added in #3471.

## Notes

- This predates #3471, which only moved this code into `_showStep`. It was deliberately left out of that PR to avoid bundling a public event-payload change into a feature PR. Rebased onto #3471 after it landed.
- This **changes a public event payload**, hence its own PR. Anyone who worked around the bug by treating `previous` as an alias for `step` will now get the real previous step, or `null` on the first step.

## Testing

Two unit tests in `shepherd.js/test/unit/tour.spec.js`:

1. On the second `show`, `previous` is the step that was showing before and is not the same object as `step`.
2. Via the `removeStep` path, `previous` is `null` rather than `undefined`.

Both were verified to fail against the unfixed code and pass with the fix.

- `pnpm test:unit:ci` — 216 passed
- `pnpm -F shepherd.js types:check:esm` — clean
- `pnpm -F shepherd.js lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)