### PR TITLE
fix: do not skip event handlers registered after a `once` handler

### DIFF
--- a/shepherd.js/src/evented.ts
+++ b/shepherd.js/src/evented.ts
@@ -51,18 +51,18 @@ export class Evented {
    * @returns
    */
   off(event: string, handler?: AnyHandler) {
-    if (isUndefined(this.bindings) || isUndefined(this.bindings[event])) {
+    const bindings = this.bindings?.[event];
+
+    if (isUndefined(bindings)) {
       return this;
     }
 
     if (isUndefined(handler)) {
       delete this.bindings[event];
     } else {
-      this.bindings[event]?.forEach((binding, index) => {
-        if (binding.handler === handler) {
-          this.bindings[event]?.splice(index, 1);
-        }
-      });
+      this.bindings[event] = bindings.filter(
+        (binding) => binding.handler !== handler
+      );
     }
 
     return this;
@@ -76,18 +76,30 @@ export class Evented {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   trigger(event: string, ...args: any[]) {
-    if (!isUndefined(this.bindings) && this.bindings[event]) {
-      this.bindings[event]?.forEach((binding, index) => {
-        const { ctx, handler, once } = binding;
+    const bindings = this.bindings?.[event];
 
-        const context = ctx || this;
+    if (isUndefined(bindings)) {
+      return this;
+    }
 
-        handler.apply(context, args as []);
+    // Iterate over a copy, since handlers may add or remove bindings while we
+    // are dispatching.
+    for (const binding of bindings.slice()) {
+      const { ctx, handler, once } = binding;
 
-        if (once) {
+      const context = ctx || this;
+
+      handler.apply(context, args as []);
+
+      if (once) {
+        // Look the binding up by identity rather than by loop index, since
+        // indexes shift as bindings are removed.
+        const index = this.bindings[event]?.indexOf(binding) ?? -1;
+
+        if (index !== -1) {
           this.bindings[event]?.splice(index, 1);
         }
-      });
+      }
     }
 
     return this;

--- a/shepherd.js/test/unit/evented.spec.js
+++ b/shepherd.js/test/unit/evented.spec.js
@@ -38,6 +38,48 @@ describe('Evented', () => {
         step: { id: 'test', text: 'A step' }
       });
     });
+
+    it('does not skip event bindings after removing an event binding', () => {
+      testEvent.once('testOn', () => true);
+      const handlerSpy = vi.fn();
+      testEvent.on('testOn', handlerSpy);
+
+      testEvent.trigger('testOn');
+
+      expect(handlerSpy).toHaveBeenCalled();
+    });
+
+    it('calls every once handler and removes all of them', () => {
+      const firstSpy = vi.fn();
+      const secondSpy = vi.fn();
+      const thirdSpy = vi.fn();
+      testEvent.once('multipleOnce', firstSpy);
+      testEvent.once('multipleOnce', secondSpy);
+      testEvent.once('multipleOnce', thirdSpy);
+
+      testEvent.trigger('multipleOnce');
+
+      expect(firstSpy).toHaveBeenCalledTimes(1);
+      expect(secondSpy).toHaveBeenCalledTimes(1);
+      expect(thirdSpy).toHaveBeenCalledTimes(1);
+      expect(
+        testEvent.bindings.multipleOnce,
+        'no spent once bindings left behind'
+      ).toHaveLength(0);
+    });
+
+    it('only calls a once handler for the first trigger', () => {
+      const onceSpy = vi.fn();
+      const onSpy = vi.fn();
+      testEvent.once('mixed', onceSpy);
+      testEvent.on('mixed', onSpy);
+
+      testEvent.trigger('mixed');
+      testEvent.trigger('mixed');
+
+      expect(onceSpy).toHaveBeenCalledTimes(1);
+      expect(onSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('off()', () => {
@@ -60,6 +102,23 @@ describe('Evented', () => {
       ).toBe(1);
     });
 
+    it('removes every binding for a handler registered more than once', () => {
+      const handler = () => {};
+      testEvent.on('testOn', handler);
+      testEvent.on('testOn', handler);
+      expect(
+        testEvent.bindings.testOn.length,
+        '3 event listeners for testOn'
+      ).toBe(3);
+
+      testEvent.off('testOn', handler);
+
+      expect(
+        testEvent.bindings.testOn.length,
+        '1 event listener for testOn'
+      ).toBe(1);
+    });
+
     it('does not remove uncreated events', () => {
       testEvent.off('testBlank');
       expect(
@@ -76,7 +135,7 @@ describe('Evented', () => {
       expect(
         testEvent.bindings.testOnce,
         'custom event removed after one trigger'
-      ).toBeTruthy();
+      ).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Supersedes #3201.

Event handlers registered after a `once` handler were silently never called. `trigger()` spliced `this.bindings[event]` while iterating it with `forEach`, so removing a spent `once` binding shifted every later binding down one while the loop still advanced — the handler that moved into the vacated slot got skipped.

@bausmeier reported this in #3201 and proposed iterating over a copy. That fixes the reported case, but not all of them: `index` becomes an index into the copy while `splice` still targets the live array, so the indexes drift as soon as more than one `once` handler is registered for the same event. Three `once` handlers all fire, but one spent binding survives and fires again on the next trigger.

So this removes `once` bindings by identity (`indexOf`) rather than by loop index.

`off()` had the same splice-during-iteration bug — registering the same handler twice and calling `off` once left one binding behind. Rewritten as a filter.

Iterating a snapshot also means a handler removed mid-dispatch still runs if it was registered when the event fired, matching Node's `EventEmitter`.

### Tests

Four new cases in `evented.spec.js`, each confirmed to fail on `main` and pass here:

- a handler registered after a `once` handler still fires (the originally reported bug)
- three `once` handlers all fire and none are left behind
- a `once` handler fires only on the first of two triggers, while an `on` handler fires on both
- `off()` removes every binding for a handler registered more than once

I also fixed an existing assertion in the `once()` block that checked `toBeTruthy()` under the message "custom event removed after one trigger" — it passed only because an empty array is truthy, so it was never testing what it claimed.

Full unit suite passes (228 tests), types and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event handling when listeners are added or removed during event dispatch.
  - Ensured one-time listeners are reliably invoked once and cleaned up afterward.
  - Corrected removal of duplicate event handlers.
  - Improved behavior when triggering events without registered listeners.

- **Tests**
  - Added coverage for one-time listeners, duplicate handlers, mixed listener types, and listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->