### PR TITLE
test: add vitest harness for the landing site

### DIFF
--- a/landing/package.json
+++ b/landing/package.json
@@ -8,7 +8,9 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.6",
@@ -26,7 +28,8 @@
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.3",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "^8.2.1",
+    "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@11.21.0"
 }

--- a/landing/test/helpers.ts
+++ b/landing/test/helpers.ts
@@ -1,0 +1,10 @@
+/** Rough visible-text extraction: drops scripts, styles, and tags. */
+export function visibleText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z#0-9]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/landing/test/setup/dev-server.ts
+++ b/landing/test/setup/dev-server.ts
@@ -1,0 +1,61 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+export const TEST_PORT = 4871;
+export const TEST_BASE_URL = `http://127.0.0.1:${TEST_PORT}`;
+
+const landingDir = fileURLToPath(new URL('../..', import.meta.url));
+
+let devServer: ChildProcess | undefined;
+
+async function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Server not up yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Dev server did not start within ${timeoutMs}ms`);
+}
+
+export default async function setup(): Promise<() => void> {
+  devServer = spawn(
+    'pnpm',
+    [
+      'exec',
+      'astro',
+      'dev',
+      '--port',
+      String(TEST_PORT),
+      '--host',
+      '127.0.0.1'
+    ],
+    {
+      cwd: landingDir,
+      stdio: 'ignore',
+      detached: true
+    }
+  );
+
+  await waitForServer(TEST_BASE_URL, 90_000);
+
+  return () => {
+    if (devServer?.pid) {
+      try {
+        // The dev server is spawned detached in its own process group so the
+        // whole tree (pnpm -> astro -> vite) can be killed together.
+        process.kill(-devServer.pid, 'SIGTERM');
+      } catch {
+        devServer.kill('SIGTERM');
+      }
+    }
+  };
+}

--- a/landing/test/smoke.e2e.test.ts
+++ b/landing/test/smoke.e2e.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { TEST_BASE_URL } from './setup/dev-server';
+
+describe('smoke', () => {
+  it('serves the homepage', async () => {
+    const response = await fetch(`${TEST_BASE_URL}/`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('Shepherd');
+  });
+});

--- a/landing/vitest.config.ts
+++ b/landing/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globalSetup: ['./test/setup/dev-server.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 120_000
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@27.4.0(supports-color@8.1.1))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
 
   packages/react:
     dependencies:
@@ -15033,7 +15036,7 @@ snapshots:
   prettier-plugin-astro@0.14.1:
     dependencies:
       '@astrojs/compiler': 2.13.1
-      prettier: 3.8.1
+      prettier: 3.9.6
       sass-formatter: 0.7.9
 
   prettier@3.8.1: {}


### PR DESCRIPTION
Part 1 of 6 of the agent-readiness stack for shepherdjs.dev (improving the site's Is Agentic score, currently 62/100).

Adds a vitest setup for the `landing` app: the global setup boots `astro dev` on port 4871 so tests make real HTTP requests against the rendered site, plus a shared HTML-text helper and a smoke test. Later PRs in the stack add per-area e2e tests on top of this.

**Test plan:** `pnpm -F landing test` (1 test passing), `pnpm -F landing build` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end smoke testing for the landing page.
  * Verifies the homepage loads successfully and displays expected content.
  * Added automatic development-server startup and cleanup for tests.
* **Chores**
  * Added Vitest configuration and commands for single-run and watch-mode testing.
  * Added HTML visible-text extraction helpers for test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->