### PR TITLE
feat: add an H1 and intro copy to the landing homepage

### DIFF
--- a/landing/src/components/Header.astro
+++ b/landing/src/components/Header.astro
@@ -72,9 +72,18 @@ const { isHome } = Astro.props;
       alt={SITE_TITLE}
     />
 
-    <h2 class="font-body p-2 text-xl">
-      Guide your users through a tour of your app
-    </h2>
+    {
+      isHome ? (
+        <h1 class="font-body p-2 text-xl">
+          <span class="sr-only">Shepherd.js — </span>
+          Guide your users through a tour of your app
+        </h1>
+      ) : (
+        <h2 class="font-body p-2 text-xl">
+          Guide your users through a tour of your app
+        </h2>
+      )
+    }
 
     {
       isHome && (

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -38,6 +38,13 @@ Astro.response.headers.set(
   </div>
 
   <div slot="content">
+    <p class="font-body mx-auto max-w-2xl p-2 text-xl">
+      Shepherd is an open-source JavaScript library for building guided product
+      tours, user onboarding, and feature announcements. Attach accessible,
+      customizable steps to any element in your app — in React, Ember, Angular,
+      Vue.js, or plain JavaScript.
+    </p>
+
     <div class="hero-including mt-8" id="hero-including">
       <h3 class="demo-heading font-heading text-2xl uppercase">
         01. How to Include

--- a/landing/test/homepage-content.e2e.test.ts
+++ b/landing/test/homepage-content.e2e.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { visibleText } from './helpers';
+import { TEST_BASE_URL } from './setup/dev-server';
+
+describe('homepage content without JavaScript', () => {
+  it('serves HTML with an H1 naming the brand', async () => {
+    const response = await fetch(`${TEST_BASE_URL}/`, {
+      headers: { Accept: 'text/html' }
+    });
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toMatch(/<h1[\s>]/);
+
+    const h1 = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/);
+    expect(visibleText(h1![1]!)).toContain('Shepherd');
+  });
+
+  it('has 500+ chars of visible text in the raw HTML', async () => {
+    const response = await fetch(`${TEST_BASE_URL}/`, {
+      headers: { Accept: 'text/html' }
+    });
+    const html = await response.text();
+
+    expect(visibleText(html).length).toBeGreaterThan(500);
+  });
+});


### PR DESCRIPTION
Part 4 of 6 of the agent-readiness stack (stacked on #3493).

The homepage had no H1 — the hero heading is an SVG image — which is why the audit reported 'no H1 tag' for content-without-JavaScript. The tagline under the hero is now an `<h1>` on the homepage (still `<h2>` elsewhere), visually unchanged, with an sr-only 'Shepherd.js —' prefix so the H1 names the brand. A short intro paragraph below the hero gives no-JS readers/crawlers meaningful descriptive content.

**Test plan:** new e2e tests assert the raw HTML contains an H1 naming Shepherd and 500+ chars of visible text — 23 tests passing on this branch. Verified visually that the hero renders identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptive homepage content explaining Shepherd’s guided tours, onboarding, feature announcements, and framework support.
  * Improved page heading structure with a primary brand heading on the homepage and appropriate secondary headings elsewhere.

* **Tests**
  * Added coverage to verify homepage accessibility and meaningful content when rendered without JavaScript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->